### PR TITLE
Lock versioned gemfiles to their respective point releases

### DIFF
--- a/gemfiles/graphql_1_10.gemfile
+++ b/gemfiles/graphql_1_10.gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem "graphql", "~> 1.10"
+gem "graphql", "~> 1.10.0"
 
 gemspec path: "../"

--- a/gemfiles/graphql_1_8.gemfile
+++ b/gemfiles/graphql_1_8.gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem "graphql", "~> 1.8"
+gem "graphql", "~> 1.8.0"
 
 gemspec path: "../"

--- a/gemfiles/graphql_1_9.gemfile
+++ b/gemfiles/graphql_1_9.gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem "graphql", "~> 1.9"
+gem "graphql", "~> 1.9.0"
 
 gemspec path: "../"


### PR DESCRIPTION
Thanks for adding support for 1.10!  I was working on adding support before I saw that you merged support so quickly, haha.  Anyway, I noticed as I was working on it that the tests for 1.8/1.9 weren't executing properly for me.

```
$ BUNDLE_GEMFILE=./gemfiles/graphql_1_8.gemfile bundle list | grep graphql
  * graphql (1.10.1)
```

I think the matchers in the Gemfiles need to be updated because they are too permissive right now  as ["\~> 1.8", "\~> 1.9", and "\~> 1.10" all match "1.10.1"](https://guides.rubygems.org/patterns/#pessimistic-version-constraint)) and don't seem to be testing what they should be.  This PR fixes it for me.