### PR TITLE
Error handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- [PR#17](https://github.com/DmitryTsepelev/graphql-ruby-persisted_queries/pull/17) Allow an optional custom error handler so that implementors can control failure scenarios when query resolution fails ([@bmorton][])
+
 ## 0.1.3 (2020-01-30)
 
 - [PR#15](https://github.com/DmitryTsepelev/graphql-ruby-persisted_queries/pull/15) Allow optional custom expiration and namespace for Redis store ([@bmorton][])

--- a/README.md
+++ b/README.md
@@ -115,6 +115,33 @@ class GraphqlSchema < GraphQL::Schema
 end
 ```
 
+## Error handling
+
+You may optionally specify an object that will be called whenever an error occurs while attempting to resolve or save a query.  This will give you the opportunity to both handle (e.g. graceful Redis failure) and/or log the error.  By default, errors will be raised when a failure occurs within a `StoreAdapter`.
+
+An error handler can be a proc or an implementation of `GraphQL::PersistedQueries::ErrorHandlers::BaseErrorHandler`.  Here's an example for treating Redis failures as cache misses:
+
+```ruby
+class GracefulRedisErrorHandler < GraphQL::PersistedQueries::ErrorHandlers::BaseErrorHandler
+  def call(error)
+    case error
+    when Redis::BaseError
+      # Treat Redis errors as a cache miss, but you should log the error into
+      # your instrumentation framework here.
+    else
+      raise error
+    end
+
+    # Return nothing to ensure handled errors are treated as cache misses
+    return
+  end
+end
+
+class GraphqlSchema < GraphQL::Schema
+  use GraphQL::PersistedQueries, error_handler: GracefulRedisErrorHandler.new
+end
+```
+
 ## GET requests and HTTP cache
 
 Using `GET` requests for persisted queries allows you to enable HTTP caching (e.g., turn on CDN). In order to make it work you should change the way link is initialized on front-end side (`createPersistedQueryLink({ useGETForHashedQueries: true })`) and register a new route `get "/graphql", to: "graphql#execute"`.

--- a/lib/graphql/persisted_queries.rb
+++ b/lib/graphql/persisted_queries.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "graphql/persisted_queries/error_handlers"
 require "graphql/persisted_queries/schema_patch"
 require "graphql/persisted_queries/store_adapters"
 require "graphql/persisted_queries/version"

--- a/lib/graphql/persisted_queries.rb
+++ b/lib/graphql/persisted_queries.rb
@@ -8,11 +8,13 @@ require "graphql/persisted_queries/version"
 module GraphQL
   # Plugin definition
   module PersistedQueries
-    def self.use(schema_defn, store: :memory, hash_generator: :sha256, **options)
+    def self.use(schema_defn, store: :memory, hash_generator: :sha256,
+                 error_handler: :default, **options)
       schema = schema_defn.is_a?(Class) ? schema_defn : schema_defn.target
 
       schema.singleton_class.prepend(SchemaPatch)
       schema.hash_generator = hash_generator
+      schema.configure_persisted_query_error_handler(error_handler)
       schema.configure_persisted_query_store(store, options)
     end
   end

--- a/lib/graphql/persisted_queries.rb
+++ b/lib/graphql/persisted_queries.rb
@@ -4,6 +4,7 @@ require "graphql/persisted_queries/error_handlers"
 require "graphql/persisted_queries/schema_patch"
 require "graphql/persisted_queries/store_adapters"
 require "graphql/persisted_queries/version"
+require "graphql/persisted_queries/builder_helpers"
 
 module GraphQL
   # Plugin definition

--- a/lib/graphql/persisted_queries/builder_helpers.rb
+++ b/lib/graphql/persisted_queries/builder_helpers.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module GraphQL
+  module PersistedQueries
+    # Contains factory methods for error handlers
+    module BuilderHelpers
+      def self.camelize(name)
+        name.to_s.split("_").map(&:capitalize).join
+      end
+    end
+  end
+end

--- a/lib/graphql/persisted_queries/error_handlers.rb
+++ b/lib/graphql/persisted_queries/error_handlers.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "graphql/persisted_queries/error_handlers/base_error_handler"
+require "graphql/persisted_queries/error_handlers/default_error_handler"
+
+module GraphQL
+  module PersistedQueries
+    # Contains factory methods for error handlers
+    module ErrorHandlers
+      def self.build(handler, options = nil)
+        if handler.is_a?(ErrorHandlers::BaseErrorHandler)
+          handler
+        else
+          build_by_name(handler, options)
+        end
+      end
+
+      def self.build_by_name(name, options)
+        camelized_handler = name.to_s.split("_").map(&:capitalize).join
+        handler_class_name = "#{camelized_handler}ErrorHandler"
+        ErrorHandlers.const_get(handler_class_name).new(options || {})
+      rescue NameError => e
+        raise e.class, "Persisted query error handler for :#{name} haven't been found", e.backtrace
+      end
+    end
+  end
+end

--- a/lib/graphql/persisted_queries/error_handlers.rb
+++ b/lib/graphql/persisted_queries/error_handlers.rb
@@ -26,9 +26,7 @@ module GraphQL
       end
 
       def self.build_by_name(name, options)
-        camelized_handler = name.to_s.split("_").map(&:capitalize).join
-        handler_class_name = "#{camelized_handler}ErrorHandler"
-        ErrorHandlers.const_get(handler_class_name).new(options || {})
+        const_get("#{BuilderHelpers.camelize(name)}ErrorHandler").new(options || {})
       rescue NameError => e
         raise e.class, "Persisted query error handler for :#{name} haven't been found", e.backtrace
       end

--- a/lib/graphql/persisted_queries/error_handlers.rb
+++ b/lib/graphql/persisted_queries/error_handlers.rb
@@ -10,9 +10,19 @@ module GraphQL
       def self.build(handler, options = nil)
         if handler.is_a?(ErrorHandlers::BaseErrorHandler)
           handler
+        elsif handler.is_a?(Proc)
+          build_from_proc(handler)
         else
           build_by_name(handler, options)
         end
+      end
+
+      def self.build_from_proc(proc)
+        if proc.arity != 1
+          raise ArgumentError, "proc passed to :error_handler should have exactly one argument"
+        end
+
+        proc
       end
 
       def self.build_by_name(name, options)

--- a/lib/graphql/persisted_queries/error_handlers/base_error_handler.rb
+++ b/lib/graphql/persisted_queries/error_handlers/base_error_handler.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module GraphQL
+  module PersistedQueries
+    module ErrorHandlers
+      # Base class for all error handlers
+      class BaseErrorHandler
+        def initialize(_options); end
+
+        def call(_error)
+          raise NotImplementedError
+        end
+      end
+    end
+  end
+end

--- a/lib/graphql/persisted_queries/error_handlers/default_error_handler.rb
+++ b/lib/graphql/persisted_queries/error_handlers/default_error_handler.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module GraphQL
+  module PersistedQueries
+    module ErrorHandlers
+      # Default error handler for simply re-raising the error
+      class DefaultErrorHandler < BaseErrorHandler
+        def call(error)
+          raise error
+        end
+      end
+    end
+  end
+end

--- a/lib/graphql/persisted_queries/schema_patch.rb
+++ b/lib/graphql/persisted_queries/schema_patch.rb
@@ -7,10 +7,14 @@ module GraphQL
   module PersistedQueries
     # Patches GraphQL::Schema to support persisted queries
     module SchemaPatch
-      attr_reader :persisted_query_store, :hash_generator_proc
+      attr_reader :persisted_query_store, :hash_generator_proc, :persisted_query_error_handler
 
       def configure_persisted_query_store(store, options)
         @persisted_query_store = StoreAdapters.build(store, options)
+      end
+
+      def configure_persisted_query_error_handler(handler)
+        @persisted_query_error_handler = ErrorHandlers.build(handler)
       end
 
       def hash_generator=(hash_generator)
@@ -19,7 +23,8 @@ module GraphQL
 
       def execute(query_str = nil, **kwargs)
         if (extensions = kwargs.delete(:extensions))
-          resolver = Resolver.new(extensions, persisted_query_store, hash_generator_proc)
+          resolver = Resolver.new(extensions, persisted_query_store, hash_generator_proc,
+                                  persisted_query_error_handler)
           query_str = resolver.resolve(query_str)
         end
 

--- a/lib/graphql/persisted_queries/store_adapters.rb
+++ b/lib/graphql/persisted_queries/store_adapters.rb
@@ -17,9 +17,7 @@ module GraphQL
       end
 
       def self.build_by_name(name, options)
-        camelized_adapter = name.to_s.split("_").map(&:capitalize).join
-        adapter_class_name = "#{camelized_adapter}StoreAdapter"
-        StoreAdapters.const_get(adapter_class_name).new(options || {})
+        const_get("#{BuilderHelpers.camelize(name)}StoreAdapter").new(options || {})
       rescue NameError => e
         raise e.class, "Persisted query store adapter for :#{name} haven't been found", e.backtrace
       end

--- a/spec/graphql/persisted_queries/builder_helpers_spec.rb
+++ b/spec/graphql/persisted_queries/builder_helpers_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe GraphQL::PersistedQueries::BuilderHelpers do
+  describe ".camelize" do
+    let(:name) { nil }
+    subject { described_class.camelize(name) }
+
+    context "when a symbol is passed" do
+      let(:name) { :this_is_a_test }
+
+      it { is_expected.to eq("ThisIsATest") }
+    end
+  end
+end

--- a/spec/graphql/persisted_queries/error_handlers/default_error_handler_spec.rb
+++ b/spec/graphql/persisted_queries/error_handlers/default_error_handler_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe GraphQL::PersistedQueries::ErrorHandlers::DefaultErrorHandler do
+  let(:options) { {} }
+  subject { described_class.new(options) }
+
+  describe "#call" do
+    context "when passed an error" do
+      it "raises the error" do
+        error = StandardError.new
+        expect { subject.call(error) }.to raise_error(error)
+      end
+    end
+  end
+end

--- a/spec/graphql/persisted_queries/error_handlers_spec.rb
+++ b/spec/graphql/persisted_queries/error_handlers_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe GraphQL::PersistedQueries::ErrorHandlers do
+  describe ".build" do
+    let(:options) { nil }
+    subject { described_class.build(handler, options) }
+
+    context "when ErrorHandlers::BaseErrorHandler instance is passed" do
+      let(:handler) do
+        GraphQL::PersistedQueries::ErrorHandlers::BaseErrorHandler.new(options)
+      end
+
+      it { is_expected.to be(handler) }
+    end
+
+    context "when name is passed" do
+      let(:handler) { :default }
+
+      it { is_expected.to be_a(GraphQL::PersistedQueries::ErrorHandlers::DefaultErrorHandler) }
+
+      context "when handler is not found" do
+        let(:handler) { :unknown }
+
+        it "raises error" do
+          expect { subject }.to raise_error(
+            NameError,
+            "Persisted query error handler for :#{handler} haven't been found"
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/graphql/persisted_queries/error_handlers_spec.rb
+++ b/spec/graphql/persisted_queries/error_handlers_spec.rb
@@ -15,6 +15,24 @@ RSpec.describe GraphQL::PersistedQueries::ErrorHandlers do
       it { is_expected.to be(handler) }
     end
 
+    context "when proc is passed" do
+      let(:handler) do
+        ->(error) { raise error }
+      end
+
+      it { is_expected.to be(handler) }
+
+      context "with wrong number of arguments" do
+        let(:handler) do
+          ->(error, more) { raise error, more }
+        end
+
+        it "raises error" do
+          expect { subject }.to raise_error(ArgumentError)
+        end
+      end
+    end
+
     context "when name is passed" do
       let(:handler) { :default }
 

--- a/spec/graphql/persisted_queries/resolver_spec.rb
+++ b/spec/graphql/persisted_queries/resolver_spec.rb
@@ -17,16 +17,17 @@ RSpec.describe GraphQL::PersistedQueries::Resolver do
     let(:query_str) { query }
     let(:hash_generator_proc) { proc { |value| Digest::SHA256.hexdigest(value) } }
     let(:hash) { hash_generator_proc.call(query) }
+    let(:error_handler) { GraphQL::PersistedQueries::ErrorHandlers::DefaultErrorHandler.new({}) }
 
     subject do
-      described_class.new(extensions, store, hash_generator_proc).resolve(query_str)
+      described_class.new(extensions, store, hash_generator_proc, error_handler).resolve(query_str)
     end
 
-    context "when hash is nil" do
+    context "when extensions hash is empty" do
       it { is_expected.to eq(query) }
     end
 
-    context "when hash is passed" do
+    context "when extensions hash is passed" do
       let(:extensions) do
         { "persistedQuery" => { "sha256Hash" => hash } }
       end
@@ -58,6 +59,51 @@ RSpec.describe GraphQL::PersistedQueries::Resolver do
         it "fetches query from store" do
           subject
           expect(store).to have_received(:fetch_query).with(hash)
+        end
+      end
+
+      context "when the store fails" do
+        let(:error_handler) do
+          handler = double("TestErrorHandler")
+          allow(handler).to receive(:call)
+          handler
+        end
+        let(:error) { StandardError.new }
+
+        context "while fetching the query" do
+          let(:query_str) { nil }
+          let(:store) do
+            store = double("TestStore")
+            allow(store).to receive(:save_query)
+            allow(store).to receive(:fetch_query).and_raise(error)
+            store
+          end
+
+          it "passes the error to the error handler" do
+            # rubocop: disable Lint/HandleExceptions
+            begin
+              subject
+            rescue GraphQL::PersistedQueries::Resolver::NotFound
+              # Ignore the expected error
+            end
+            # rubocop: enable Lint/HandleExceptions
+
+            expect(error_handler).to have_received(:call).with(error)
+          end
+        end
+
+        context "while saving the query" do
+          let(:store) do
+            store = double("TestStore")
+            allow(store).to receive(:save_query).and_raise(error)
+            allow(store).to receive(:fetch_query)
+            store
+          end
+
+          it "passes the error to the error handler" do
+            subject
+            expect(error_handler).to have_received(:call).with(error)
+          end
         end
       end
     end

--- a/spec/graphql/persisted_queries/schema_patch_spec.rb
+++ b/spec/graphql/persisted_queries/schema_patch_spec.rb
@@ -13,8 +13,17 @@ RSpec.describe GraphQL::PersistedQueries::SchemaPatch do
     end
   end
 
+  TestErrorHandler = Class.new(GraphQL::PersistedQueries::ErrorHandlers::BaseErrorHandler) do
+    attr_accessor :last_handled_error
+
+    def call(error)
+      self.last_handled_error = error
+      raise error
+    end
+  end
+
   GraphqlSchema = Class.new(GraphQL::Schema) do
-    use GraphQL::PersistedQueries
+    use GraphQL::PersistedQueries, error_handler: TestErrorHandler.new({})
 
     query QueryType
   end
@@ -51,6 +60,40 @@ RSpec.describe GraphQL::PersistedQueries::SchemaPatch do
 
     it "returns data" do
       expect(response["data"]).to eq("someData" => "some value")
+    end
+  end
+
+  context "when cache is unavailable" do
+    let(:query) { nil }
+    let(:sha256) { 1 }
+
+    UnavailableStore = Class.new(GraphQL::PersistedQueries::StoreAdapters::BaseStoreAdapter) do
+      def fetch_query(_)
+        raise "Store unavailable"
+      end
+
+      def save_query(_, _)
+        raise "Store unavailable"
+      end
+    end
+
+    around do |test|
+      original_store = GraphqlSchema.persisted_query_store
+      GraphqlSchema.configure_persisted_query_store(UnavailableStore.new({}), {})
+      test.run
+      GraphqlSchema.configure_persisted_query_store(original_store, {})
+    end
+
+    it "calls the error handler" do
+      # rubocop: disable Lint/HandleExceptions
+      begin
+        perform_request
+      rescue RuntimeError
+        # Ignore the expected error
+      end
+      # rubocop: enable Lint/HandleExceptions
+
+      expect(GraphqlSchema.persisted_query_error_handler.last_handled_error).to be_a(RuntimeError)
     end
   end
 end


### PR DESCRIPTION
Accidentally opened this before it was ready — I’ve updated the description below:

This PR adds error handlers similar to discussed in #16.  I started implementing this at the RedisStoreAdapter level, but this seemed better because it can be used more broadly and doesn’t require implementation at each of the stores.

I tried following other patterns in the repo, but I’m happy to change things that seem overly complex.  I’m undecided if I want to include something into the repo for handling failures more gracefully because there doesn’t seem to be a good way to hook it into the implementing application's instrumentation framework.  Having an error handler that just silently swallows these things seemed like it would promote a bad practice.  Instead, I think I will implement the error handler in my application and use this to integrate it.  Thoughts?

I still need to add some documentation and update the change log if you’re happy with this approach.