### PR TITLE
Initial spike for instrumentation via graphql-ruby's tracer feature

### DIFF
--- a/lib/graphql/persisted_queries/resolver.rb
+++ b/lib/graphql/persisted_queries/resolver.rb
@@ -18,19 +18,26 @@ module GraphQL
         end
       end
 
-      def initialize(extensions, store, hash_generator_proc)
+      include GraphQL::Tracing::Traceable
+
+      def initialize(extensions, store, hash_generator_proc, tracers: nil)
         @extensions = extensions
         @store = store
         @hash_generator_proc = hash_generator_proc
+        @tracers = tracers || []
       end
 
       def resolve(query_str)
         return query_str if hash.nil?
 
         if query_str
-          persist_query(query_str)
+          trace("persist_query", hash: hash) do
+            persist_query(query_str)
+          end
         else
-          query_str = @store.fetch_query(hash)
+          trace("fetch_query", hash: hash) do
+            query_str = @store.fetch_query(hash)
+          end
           raise NotFound if query_str.nil?
         end
 

--- a/lib/graphql/persisted_queries/schema_patch.rb
+++ b/lib/graphql/persisted_queries/schema_patch.rb
@@ -19,7 +19,7 @@ module GraphQL
 
       def execute(query_str = nil, **kwargs)
         if (extensions = kwargs.delete(:extensions))
-          resolver = Resolver.new(extensions, persisted_query_store, hash_generator_proc)
+          resolver = Resolver.new(extensions, persisted_query_store, hash_generator_proc, tracers: tracers)
           query_str = resolver.resolve(query_str)
         end
 


### PR DESCRIPTION
As discussed in #18, I spiked out what this might look like if we use `graphql-ruby`'s tracers feature.  This is not ready for merge yet, but wanted to get some early feedback if possible.

It's a little awkward, but I think this would work.  It's weird because the event is when the thing is *going* to happen, not when it has happened.  Fortunately, `graphql-ruby` yields to the tracer, so you can get the result of the yield, handle that result, and then return that result.  I think the yield is mainly for benchmarking and instrumenting, though.

With how this is currently implemented, you can get the result of each call (for `fetch_query` and `persist_query` and then you can instrument things like "cache hit").  I feel like it'd be more solid to communicate an event like `"fetch_query.cache_hit"`, but that doesn't seem in the spirit of how these tracers work.

One other interesting thing is that if we have tracers on these two events, we could conceivably use this for the "error handling" feature too since it also yields.  I think in code, it could make sense to combine them, but conceptually using a tracer for error handling seems odd.  I think I'd still leave the error handling support even with the tracers, but I've been going back and forth on it.

Thoughts on any of this?  Ultimately, I think this is the right way forward, but wanted to check in if these things matched your understanding of how tracers work.