### PR TITLE
Adapter for Redis-backed in-memory store

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,14 @@ class GraphqlSchema < GraphQL::Schema
 end
 ```
 
+### Supported stores
+
+We currently support a few different stores that can be configured out of the box:
+
+- `:memory`: This is the default in-memory store and is great for getting started, but will require each instance to cache results independently which can result in lots of ["new query path"](https://blog.apollographql.com/improve-graphql-performance-with-automatic-persisted-queries-c31d27b8e6ea) requests.
+- `:redis`: This store will allow you to share a Redis cache across all instances of your GraphQL application so that each instance doesn't have to ask the client for the query again if it hasn't seen it yet.
+- `:redis_with_local_cache`: This store combines both the `:memory` and `:redis` approaches so that we can reduce the number of network requests we make while mitigating the independent cache issue.  This adapter is configured identically to the `:redis` store.
+
 ## Alternative hash functions
 
 [apollo-link-persisted-queries](https://github.com/apollographql/apollo-link-persisted-queries) uses _SHA256_ by default so this gem uses it as a default too, but if you want to override it – you can use `:hash_generator` option:

--- a/lib/graphql/persisted_queries/store_adapters.rb
+++ b/lib/graphql/persisted_queries/store_adapters.rb
@@ -3,6 +3,7 @@
 require "graphql/persisted_queries/store_adapters/base_store_adapter"
 require "graphql/persisted_queries/store_adapters/memory_store_adapter"
 require "graphql/persisted_queries/store_adapters/redis_store_adapter"
+require "graphql/persisted_queries/store_adapters/redis_with_local_cache_store_adapter"
 
 module GraphQL
   module PersistedQueries

--- a/lib/graphql/persisted_queries/store_adapters/redis_with_local_cache_store_adapter.rb
+++ b/lib/graphql/persisted_queries/store_adapters/redis_with_local_cache_store_adapter.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module GraphQL
+  module PersistedQueries
+    module StoreAdapters
+      # Memory adapter for storing persisted queries
+      class RedisWithLocalCacheStoreAdapter < BaseStoreAdapter
+        DEFAULT_REDIS_ADAPTER_CLASS = RedisStoreAdapter
+        DEFAULT_MEMORY_ADAPTER_CLASS = MemoryStoreAdapter
+
+        def initialize(redis_client:, expiration: nil, namespace: nil, redis_adapter_class: nil,
+                       memory_adapter_class: nil)
+          redis_adapter_class ||= DEFAULT_REDIS_ADAPTER_CLASS
+          memory_adapter_class ||= DEFAULT_MEMORY_ADAPTER_CLASS
+
+          @redis_adapter = redis_adapter_class.new(
+            redis_client: redis_client,
+            expiration: expiration,
+            namespace: namespace
+          )
+          @memory_adapter = memory_adapter_class.new(nil)
+        end
+
+        def fetch_query(hash)
+          result = @memory_adapter.fetch_query(hash)
+          result ||= begin
+            inner_result = @redis_adapter.fetch_query(hash)
+            @memory_adapter.save_query(hash, inner_result) if inner_result
+            inner_result
+          end
+          result
+        end
+
+        def save_query(hash, query)
+          @redis_adapter.save_query(hash, query)
+          @memory_adapter.save_query(hash, query)
+        end
+
+        private
+
+        attr_reader :redis_adapter, :memory_adapter
+      end
+    end
+  end
+end

--- a/spec/graphql/persisted_queries/store_adapters/redis_with_local_cache_store_adapter_spec.rb
+++ b/spec/graphql/persisted_queries/store_adapters/redis_with_local_cache_store_adapter_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "redis"
+require "connection_pool"
+
+RSpec.describe GraphQL::PersistedQueries::StoreAdapters::RedisWithLocalCacheStoreAdapter do
+  subject { described_class.new(options) }
+
+  let(:redis_client) { { redis_url: "redis://127.0.0.3:8791/3" } }
+  let(:mock_redis_adapter) { double("RedisStoreAdapterDouble") }
+  let(:redis_adapter_class) do
+    klass = double("RedisStoreAdapterClassDouble")
+    allow(klass).to receive(:new).and_return(mock_redis_adapter)
+    klass
+  end
+  let(:mock_memory_adapter) { double("MemoryStoreAdapterDouble") }
+  let(:memory_adapter_class) do
+    klass = double("MemoryStoreAdapterClassDouble")
+    allow(klass).to receive(:new).and_return(mock_memory_adapter)
+    klass
+  end
+  let(:options) do
+    {
+      redis_client: redis_client,
+      expiration: nil,
+      namespace: nil,
+      redis_adapter_class: redis_adapter_class,
+      memory_adapter_class: memory_adapter_class
+    }
+  end
+
+  context "when configuring the redis adapter" do
+    it "passes config options to adapter" do
+      subject
+      expect(redis_adapter_class).to have_received(:new).with(redis_client: options[:redis_client],
+                                                              expiration: options[:expiration],
+                                                              namespace: options[:namespace])
+    end
+  end
+
+  context "when fetching queries" do
+    it "delegates to the memory adapter" do
+      expect(mock_memory_adapter).to receive(:fetch_query).with("abc123").and_return("result!")
+      subject.fetch_query("abc123")
+    end
+
+    context "with memory adapter cache miss" do
+      before do
+        allow(mock_memory_adapter).to receive(:fetch_query).with("abc123").and_return(nil)
+        allow(mock_memory_adapter).to receive(:save_query)
+      end
+
+      it "delegates to the redis adapter" do
+        expect(mock_redis_adapter).to receive(:fetch_query).with("abc123").and_return("result!")
+        subject.fetch_query("abc123")
+      end
+
+      context "with redis adapter cache miss" do
+        before do
+          allow(mock_redis_adapter).to receive(:fetch_query).with("abc123").and_return(nil)
+        end
+
+        it "doesn't persist the result to the memory adapter" do
+          expect(mock_memory_adapter).not_to receive(:save_query)
+          subject.fetch_query("abc123")
+        end
+      end
+
+      context "with redis adapter cache hit" do
+        before do
+          allow(mock_redis_adapter).to receive(:fetch_query).with("abc123").and_return("result!")
+        end
+
+        it "persists the result to the memory adapter" do
+          expect(mock_memory_adapter).to receive(:save_query).with("abc123", "result!")
+          subject.fetch_query("abc123")
+        end
+      end
+    end
+  end
+
+  context "when saving queries" do
+    it "dispatches to both adapters" do
+      expect(mock_memory_adapter).to receive(:save_query).with("abc123", "result!")
+      expect(mock_redis_adapter).to receive(:save_query).with("abc123", "result!")
+      subject.save_query("abc123", "result!")
+    end
+  end
+end


### PR DESCRIPTION
As discussed in #20, this PR introduces a new store adapter: `RedisWithLocalCacheStoreAdapter`

Since the in-memory storage adapter has the drawback of each node populating it's own cache and the Redis storage adapter requires remote calls over the network, this `RedisWithLocalCacheStoreAdapter` takes a hybrid approach that keeps an in-memory cache fresh while delegating cache misses to the Redis adapter for in-memory population.  This allows us to force clients into the "new query path" less frequently and avoids unnecessary remote network calls.

With the assumption that hashes always resolve to the same query, no invalidation is needed for the in-memory stores.