### PR TITLE
Add support for memcached store adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- [PR#26](https://github.com/DmitryTsepelev/graphql-ruby-persisted_queries/pull/26) Add Memcached store ([@JanStevens][])
+
 ## 0.3.0 (2020-02-21)
 
 - [PR#24](https://github.com/DmitryTsepelev/graphql-ruby-persisted_queries/pull/24) Add multiplex support ([@DmitryTsepelev][])

--- a/README.md
+++ b/README.md
@@ -126,7 +126,9 @@ class GraphqlSchema < GraphQL::Schema
 end
 ```
 
-You can also pass options for `expiration` and `namespace` to override the defaults and you can configure the Dalli `pool_size` and `compress` option:
+You can also pass options for `expiration` and `namespace` to override the defaults. 
+Any additional argument inside `dalli_client` will be forwarded to `Dalli::Client.new`. 
+Following example configures Dalli `pool_size` and `compress` options:
 
 ```ruby
 class GraphqlSchema < GraphQL::Schema
@@ -134,8 +136,8 @@ class GraphqlSchema < GraphQL::Schema
       store: :memcached,
       dalli_client: { 
         memcached_url: "127.0.0.2:11211", 
-        pool_size: 5, # default is 5
-        compress: true # default is true
+        pool_size: 5,
+        compress: true
       },
       expiration: 172800, # optional, default is 24 hours
       namespace: "my-custom-namespace" # optional, default is "graphql-persisted-query"

--- a/README.md
+++ b/README.md
@@ -59,11 +59,12 @@ GraphqlSchema.execute(
 
 ## Usage with BatchLink
 
-It's possible to group queries using [batch-link](https://www.apollographql.com/docs/link/links/batch-http/) and send them as a single HTTP request. In this case you need to use `GraphqlSchema.multiplex(queries)` instead of `#execute`. The gem supports it too, no action required!
+It's possible to group queries using [batch-link](https://www.apollographql.com/docs/link/links/batch-http/) and send them as a single HTTP request. 
+In this case you need to use `GraphqlSchema.multiplex(queries)` instead of `#execute`. The gem supports it too, no action required!
 
 ## Alternative stores
 
-All the queries are stored in memory by default, but you can easily switch to _redis_:
+All the queries are stored in memory by default, but you can easily switch to _redis_ or _memcached_:
 
 ```ruby
 class GraphqlSchema < GraphQL::Schema
@@ -71,7 +72,10 @@ class GraphqlSchema < GraphQL::Schema
 end
 ```
 
-If you have `ENV["REDIS_URL"]` configured – you don't need to pass it explicitly. Also, you can pass `:redis_host`, `:redis_port` and `:redis_db_name` inside the `:redis_client` hash to build the URL from scratch or pass the configured `Redis` or `ConnectionPool` object:
+### Redis
+
+If you have `ENV["REDIS_URL"]` configured – you don't need to pass it explicitly. Also, you can pass `:redis_host`, `:redis_port` and `:redis_db_name` 
+inside the `:redis_client` hash to build the URL from scratch or pass the configured `Redis` or `ConnectionPool` object:
 
 ```ruby
 class GraphqlSchema < GraphQL::Schema
@@ -101,6 +105,43 @@ class GraphqlSchema < GraphQL::Schema
 end
 ```
 
+### Memcached
+
+If you have `ENV["MEMCACHE_SERVERS"]` configured - you don't need to pass it explicitly. Also, you can pass `:memcached_host` and `:memcached_port` 
+inside the `:dalli_client` hash to build the server name from scratch or pass the configured `Dalli::Client` object:
+
+```ruby
+class GraphqlSchema < GraphQL::Schema
+  use GraphQL::PersistedQueries,
+      store: :memcached,
+      dalli_client: { memcached_host: "127.0.0.2", memcached_port: "11211" }
+  # or
+  use GraphQL::PersistedQueries,
+      store: :memcached,
+      dalli_client: Dalli::Client.new("127.0.0.2:11211")
+  # or
+  use GraphQL::PersistedQueries,
+      store: :memcached,
+      dalli_client: { memcached_url: "127.0.0.2:11211" }
+end
+```
+
+You can also pass options for `expiration` and `namespace` to override the defaults and you can configure the Dalli `pool_size` and `compress` option:
+
+```ruby
+class GraphqlSchema < GraphQL::Schema
+  use GraphQL::PersistedQueries,
+      store: :memcached,
+      dalli_client: { 
+        memcached_url: "127.0.0.2:11211", 
+        pool_size: 5, # default is 5
+        compress: true # default is true
+      },
+      expiration: 172800, # optional, default is 24 hours
+      namespace: "my-custom-namespace" # optional, default is "graphql-persisted-query"
+end
+```
+
 ### Supported stores
 
 We currently support a few different stores that can be configured out of the box:
@@ -108,6 +149,7 @@ We currently support a few different stores that can be configured out of the bo
 - `:memory`: This is the default in-memory store and is great for getting started, but will require each instance to cache results independently which can result in lots of ["new query path"](https://blog.apollographql.com/improve-graphql-performance-with-automatic-persisted-queries-c31d27b8e6ea) requests.
 - `:redis`: This store will allow you to share a Redis cache across all instances of your GraphQL application so that each instance doesn't have to ask the client for the query again if it hasn't seen it yet.
 - `:redis_with_local_cache`: This store combines both the `:memory` and `:redis` approaches so that we can reduce the number of network requests we make while mitigating the independent cache issue.  This adapter is configured identically to the `:redis` store.
+- `:memcached`: This store will allow you to share a Memcached cache across all instances of your GraphQL application. The client is implemented with the Dalli gem.
 
 ## Alternative hash functions
 

--- a/graphql-persisted_queries.gemspec
+++ b/graphql-persisted_queries.gemspec
@@ -28,5 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", ">= 10.0"
   spec.add_development_dependency "rubocop", "0.75"
   spec.add_development_dependency "redis"
+  spec.add_development_dependency "dalli"
   spec.add_development_dependency "connection_pool"
 end

--- a/lib/graphql/persisted_queries/store_adapters.rb
+++ b/lib/graphql/persisted_queries/store_adapters.rb
@@ -4,6 +4,7 @@ require "graphql/persisted_queries/store_adapters/base_store_adapter"
 require "graphql/persisted_queries/store_adapters/memory_store_adapter"
 require "graphql/persisted_queries/store_adapters/redis_store_adapter"
 require "graphql/persisted_queries/store_adapters/redis_with_local_cache_store_adapter"
+require "graphql/persisted_queries/store_adapters/memcached_store_adapter"
 
 module GraphQL
   module PersistedQueries

--- a/lib/graphql/persisted_queries/store_adapters/memcached_client_builder.rb
+++ b/lib/graphql/persisted_queries/store_adapters/memcached_client_builder.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module GraphQL
+  module PersistedQueries
+    module StoreAdapters
+      # Builds Redis object instance based on passed hash
+      class MemcachedClientBuilder
+        def initialize(memcached_url: nil, memcached_host: nil, memcached_port: nil,
+                       pool_size: 5, compress: true)
+          require "dalli"
+
+          @memcached_url = memcached_url
+          @memcached_host = memcached_host
+          @memcached_port = memcached_port
+          @pool_size = pool_size
+          @compress = compress
+        rescue LoadError => e
+          msg = "Could not load the 'dalli' gem, please add it to your gemfile or " \
+                "configure a different adapter, e.g. use GraphQL::PersistedQueries, store: :memory"
+          raise e.class, msg, e.backtrace
+        end
+
+        def build
+          if @memcached_url && (@memcached_host || @memcached_port)
+            raise ArgumentError, "memcached_url cannot be passed along with memcached_host or " \
+                                 "memcached_port options"
+          end
+
+          ::Dalli::Client.new(@memcached_url || build_memcached_url,
+                              pool_size: @pool_size, compress: @compress)
+        end
+
+        private
+
+        def build_memcached_url
+          "#{@memcached_host}:#{@memcached_port}"
+        end
+      end
+    end
+  end
+end

--- a/lib/graphql/persisted_queries/store_adapters/memcached_client_builder.rb
+++ b/lib/graphql/persisted_queries/store_adapters/memcached_client_builder.rb
@@ -5,15 +5,13 @@ module GraphQL
     module StoreAdapters
       # Builds Redis object instance based on passed hash
       class MemcachedClientBuilder
-        def initialize(memcached_url: nil, memcached_host: nil, memcached_port: nil,
-                       pool_size: 5, compress: true)
+        def initialize(memcached_url: nil, memcached_host: nil, memcached_port: nil, **dalli_args)
           require "dalli"
 
           @memcached_url = memcached_url
           @memcached_host = memcached_host
           @memcached_port = memcached_port
-          @pool_size = pool_size
-          @compress = compress
+          @dalli_args = dalli_args
         rescue LoadError => e
           msg = "Could not load the 'dalli' gem, please add it to your gemfile or " \
                 "configure a different adapter, e.g. use GraphQL::PersistedQueries, store: :memory"
@@ -26,8 +24,7 @@ module GraphQL
                                  "memcached_port options"
           end
 
-          ::Dalli::Client.new(@memcached_url || build_memcached_url,
-                              pool_size: @pool_size, compress: @compress)
+          ::Dalli::Client.new(@memcached_url || build_memcached_url, **@dalli_args)
         end
 
         private

--- a/lib/graphql/persisted_queries/store_adapters/memcached_store_adapter.rb
+++ b/lib/graphql/persisted_queries/store_adapters/memcached_store_adapter.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "graphql/persisted_queries/store_adapters/memcached_client_builder"
+
+module GraphQL
+  module PersistedQueries
+    module StoreAdapters
+      # Redis adapter for storing persisted queries
+      class MemcachedStoreAdapter < BaseStoreAdapter
+        DEFAULT_EXPIRATION = 24 * 60 * 60
+        DEFAULT_NAMESPACE = "graphql-persisted-query"
+
+        def initialize(dalli_client:, expiration: nil, namespace: nil)
+          @dalli_proc = build_dalli_proc(dalli_client)
+          @expiration = expiration || DEFAULT_EXPIRATION
+          @namespace = namespace || DEFAULT_NAMESPACE
+        end
+
+        def fetch_query(hash)
+          @dalli_proc.call { |dalli| dalli.get(key_for(hash)) }
+        end
+
+        def save_query(hash, query)
+          @dalli_proc.call { |dalli| dalli.set(key_for(hash), query, @expiration) }
+        end
+
+        private
+
+        def key_for(hash)
+          "#{@namespace}:#{hash}"
+        end
+
+        def build_dalli_proc(dalli_client)
+          if dalli_client.is_a?(Hash)
+            build_dalli_proc(MemcachedClientBuilder.new(dalli_client).build)
+          elsif dalli_client.is_a?(Proc)
+            dalli_client
+          elsif defined?(::Dalli::Client) && dalli_client.is_a?(::Dalli::Client)
+            proc { |&b| b.call(dalli_client) }
+          else
+            raise ArgumentError, ":dalli_client accepts Dalli::Client, Hash or Proc only"
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/graphql/persisted_queries/store_adapters/memcached_client_builder_spec.rb
+++ b/spec/graphql/persisted_queries/store_adapters/memcached_client_builder_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dalli"
+
+RSpec.describe GraphQL::PersistedQueries::StoreAdapters::MemcachedClientBuilder do
+  describe "#initialize" do
+    let(:options) { {} }
+
+    subject { described_class.new(options).build }
+
+    context "when memcached_host, memcached_port and memcached_db_name are passed" do
+      let(:options) do
+        { memcached_host: "127.0.0.2", memcached_port: "11211" }
+      end
+
+      it "builds memcached URL" do
+        expect(::Dalli::Client).to receive(:new).with("127.0.0.2:11211",
+                                                      compress: true, pool_size: 5)
+        subject
+      end
+    end
+
+    context "when memcached_url is passed" do
+      let(:options) { { memcached_url: "127.0.0.4:11211" } }
+
+      it "uses passed memcached_url" do
+        expect(::Dalli::Client).to receive(:new).with("127.0.0.4:11211",
+                                                      compress: true, pool_size: 5)
+        subject
+      end
+
+      context "when passed along with other parameters" do
+        let(:options) do
+          {
+            memcached_url: "127.0.0.1:11211",
+            memcached_host: "127.0.0.1",
+            memcached_port: "11211"
+          }
+        end
+
+        it "raises error" do
+          expect { subject }.to raise_error(
+            ArgumentError,
+            "memcached_url cannot be passed along with memcached_host or memcached_port options"
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/graphql/persisted_queries/store_adapters/memcached_client_builder_spec.rb
+++ b/spec/graphql/persisted_queries/store_adapters/memcached_client_builder_spec.rb
@@ -15,8 +15,18 @@ RSpec.describe GraphQL::PersistedQueries::StoreAdapters::MemcachedClientBuilder 
       end
 
       it "builds memcached URL" do
-        expect(::Dalli::Client).to receive(:new).with("127.0.0.2:11211",
-                                                      compress: true, pool_size: 5)
+        expect(::Dalli::Client).to receive(:new).with("127.0.0.2:11211", {})
+        subject
+      end
+    end
+
+    context "when additional arguments are given" do
+      let(:options) do
+        { memcached_host: "127.0.0.2", memcached_port: "11211", compress: true, pool_size: 5 }
+      end
+
+      it "delegats to dalli client" do
+        expect(::Dalli::Client).to receive(:new).with("127.0.0.2:11211", compress: true, pool_size: 5)
         subject
       end
     end
@@ -25,8 +35,7 @@ RSpec.describe GraphQL::PersistedQueries::StoreAdapters::MemcachedClientBuilder 
       let(:options) { { memcached_url: "127.0.0.4:11211" } }
 
       it "uses passed memcached_url" do
-        expect(::Dalli::Client).to receive(:new).with("127.0.0.4:11211",
-                                                      compress: true, pool_size: 5)
+        expect(::Dalli::Client).to receive(:new).with("127.0.0.4:11211", {})
         subject
       end
 

--- a/spec/graphql/persisted_queries/store_adapters/memcached_client_builder_spec.rb
+++ b/spec/graphql/persisted_queries/store_adapters/memcached_client_builder_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe GraphQL::PersistedQueries::StoreAdapters::MemcachedClientBuilder 
       end
 
       it "delegats to dalli client" do
-        expect(::Dalli::Client).to receive(:new).with("127.0.0.2:11211", compress: true, pool_size: 5)
+        expect(::Dalli::Client).to receive(:new).with("127.0.0.2:11211",
+                                                      compress: true, pool_size: 5)
         subject
       end
     end

--- a/spec/graphql/persisted_queries/store_adapters/memcached_store_adapter_spec.rb
+++ b/spec/graphql/persisted_queries/store_adapters/memcached_store_adapter_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "dalli"
+
+RSpec.describe GraphQL::PersistedQueries::StoreAdapters::MemcachedStoreAdapter do
+  subject { described_class.new(options) }
+
+  let(:expiration) { nil }
+  let(:namespace) { nil }
+  let(:options) do
+    {
+      dalli_client: dalli_client,
+      expiration: expiration,
+      namespace: namespace
+    }
+  end
+
+  context "when Hash instance is passed" do
+    let(:dalli_client) { { memcached_url: "127.0.0.3:11211" } }
+
+    it "wraps with proc" do
+      expect(subject.instance_variable_get("@dalli_proc")).to be_kind_of(Proc)
+    end
+  end
+
+  context "when Proc instance is passed" do
+    let(:dalli_client) { proc {} }
+
+    it "wraps with proc" do
+      expect(subject.instance_variable_get("@dalli_proc")).to be_kind_of(Proc)
+    end
+  end
+
+  context "when Dalli::Client instance is passed" do
+    let(:dalli_client) { Dalli::Client.new("127.0.0.3:11211") }
+
+    it "wraps with proc" do
+      expect(subject.instance_variable_get("@dalli_proc")).to be_kind_of(Proc)
+    end
+  end
+
+  context "when expiration is not passed" do
+    let(:dalli_client) { proc {} }
+
+    it "falls back to the default expiration" do
+      expect(subject.instance_variable_get("@expiration")).to eq(86400)
+    end
+  end
+
+  context "when expiration is passed" do
+    let(:dalli_client) { proc {} }
+    let(:expiration) { 1_000_000 }
+
+    it "uses the passed expiration" do
+      expect(subject.instance_variable_get("@expiration")).to eq(expiration)
+    end
+  end
+
+  context "when namespace is not passed" do
+    let(:dalli_client) { proc {} }
+
+    it "falls back to the default namespace" do
+      expect(subject.instance_variable_get("@namespace")).to eq("graphql-persisted-query")
+    end
+  end
+
+  context "when namespace is passed" do
+    let(:dalli_client) { proc {} }
+    let(:namespace) { "my-very-own-namespace" }
+
+    it "uses the passed namespace" do
+      expect(subject.instance_variable_get("@namespace")).to eq(namespace)
+    end
+  end
+
+  context "when not supported object is passed" do
+    let(:dalli_client) { 42 }
+
+    it "raises error" do
+      expect { subject }.to raise_error(
+        ArgumentError,
+        ":dalli_client accepts Dalli::Client, Hash or Proc only"
+      )
+    end
+  end
+end


### PR DESCRIPTION
Implements #6 

I took over the pattern from Redis and adapted it for memcached using the Dalli gem. I do allow to pass in the `compress` and `pool_size` options from the Dalli gem.

Potentially you could do a lot more when using the memcached_url since it can be an array and you can add weights to your memcached instances.

Let me know what to adapt, probably a bunch of documentation needs to be added