### PR TITLE
Adding Squish

### DIFF
--- a/lib/graphql/persisted_queries/resolver.rb
+++ b/lib/graphql/persisted_queries/resolver.rb
@@ -46,8 +46,12 @@ module GraphQL
 
       def persist_query(query_str)
         raise WrongHash if @schema.hash_generator_proc.call(query_str) != hash
+        squished_query = @schema.persisted_query_squish ? squish_str(query_str) : query_str
+        with_error_handling { @schema.persisted_query_store.save_query(hash, squished_query) }
+      end
 
-        with_error_handling { @schema.persisted_query_store.save_query(hash, query_str) }
+      def squish_str(str)
+        str.dup.gsub(/[[:space:]]+/, " ").strip
       end
 
       def hash

--- a/lib/graphql/persisted_queries/schema_patch.rb
+++ b/lib/graphql/persisted_queries/schema_patch.rb
@@ -15,7 +15,8 @@ module GraphQL
         end
       end
 
-      attr_reader :persisted_query_store, :hash_generator_proc, :persisted_query_error_handler
+      attr_reader :persisted_query_store, :hash_generator_proc,
+        :persisted_query_error_handler, :persisted_query_squish
 
       def configure_persisted_query_store(store, options)
         @persisted_query_store = StoreAdapters.build(store, options)
@@ -23,6 +24,10 @@ module GraphQL
 
       def configure_persisted_query_error_handler(handler)
         @persisted_query_error_handler = ErrorHandlers.build(handler)
+      end
+
+      def configure_squish_queries(squish)
+        @persisted_query_squish = squish
       end
 
       def hash_generator=(hash_generator)


### PR DESCRIPTION
Implements #27 

I did the first POC but I was a bit torn on the implementation, I see two possible ways:

1. in `resolver.rb` when we call `persist_query` on the store (this is done in this MR)
2. Expand the adapters so public methods `persist_query` actually delegates to `store_presist_query` and every store implements not `persist_query` but `store_persist_query`

```ruby
class BaseStoreAdapter
  def fetch_query(hash)
     store_fetch_query(hash)
  end

  def save_query(hash, query)
     # Add squish here
     store_save_query(hash, query)
  end
end

class MemoryStoreAdapter < BaseStoreAdapter
  def initialize(_options)
    @storage = {}
  end

  def store_fetch_query(hash)
     @storage[hash]
  end

  def store_save_query(hash, query)
    @storage[hash] = query
  end
end
```
