### PR TITLE
Instrumentation via graphql-ruby's tracer feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- [PR#29](https://github.com/DmitryTsepelev/graphql-ruby-persisted_queries/pull/29) Instrumentation via graphql-ruby's tracer feature ([@bmorton][])
+
 ## 0.4.0 (2020-02-26)
 
 - [PR#26](https://github.com/DmitryTsepelev/graphql-ruby-persisted_queries/pull/26) Add Memcached store ([@JanStevens][])

--- a/README.md
+++ b/README.md
@@ -208,6 +208,10 @@ Using `GET` requests for persisted queries allows you to enable HTTP caching (e.
 
 HTTP method verification is important, because when mutations are allowed via `GET` requests, it's easy to perform an attack by sending the link containing mutation to a signed in user.
 
+## Tracing and instrumentation
+
+An experimental tracing feature can be enabled by setting `tracing: true` when configuring the plugin.  Read more about this feature in the [Tracing guide](docs/tracing.md).
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/DmitryTsepelev/graphql-ruby-persisted_queries.

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -1,0 +1,51 @@
+# Tracing
+
+Tracing is an experimental feature that, when enabled, uses the tracing system defined in `graphql-ruby` to surface these events:
+
+* `persisted_queries.fetch_query.cache_hit` - Triggered when a store adapter successfully looks up a hash and finds a query.
+* `persisted_queries.fetch_query.cache_miss` - Triggered when a store adapter attempts to look up a hash but cannot find it.
+* `persisted_queries.save_query` - Triggered when a store adapter persists a query.
+
+All events include a metadata hash as their `data` parameter.  This hash currently only includes the name of the adapter that triggered the event.
+
+## Usage
+
+Tracing must be opted into via the plugin configuration for the events to trigger.  Once they are enabled, any tracer that is defined on the schema will get the following events yielded to them.  An example configuration will look similar to this:
+
+```ruby
+class GraphqlSchema < GraphQL::Schema
+  use GraphQL::PersistedQueries, tracing: true
+  tracer MyPersistedQueriesTracer
+end
+```
+
+Tracers in this plugin integrate with the `GraphQL::Tracing` feature in [`graphql-ruby`](https://github.com/rmosolgo/graphql-ruby).  The same tracers are used for tracing events directly from `graphql-ruby` and this plugin.  The [guide on "Tracing"](https://graphql-ruby.org/queries/tracing.html) in `graphql-ruby` has implementation details, but an example tracer would look similar to this:
+
+```ruby
+class MyPersistedQueriesTracer
+  def self.trace(key, data)
+    yield.tap do |result|
+      # Note: this tracer will get called for these persisted queries events as
+      # well as all events traced by the graphql-ruby gem.
+      case key
+      when "persisted_queries.fetch_query.cache_hit"
+        # data = { adapter: :redis }
+        # result = nil
+        # increment a counter metric to track cache hits
+      when "persisted_queries.fetch_query.cache_miss"
+        # data = { adapter: :redis }
+        # result = nil
+        # increment a counter metric to track cache misses
+      when "persisted_queries.save_query"
+        # data = { adapter: :redis }
+        # result = return value from method call
+        # increment a counter metric to track saved queries
+      end
+    end
+  end
+end
+```
+
+## Be aware of tracers-as-notifications
+
+A word of caution about the `cache_hit` and `cache_miss` events: they yield an empty block.  The `GraphQL::Tracing` feature typically wraps around the code performing the event.  The `save_query` event works this way, too -- the block that is yielded is essentially the `StoreAdapter#save` method.  This means you can add timing instrumentation for this call.  However, the `cache_hit` and `cache_miss` events are simply event notifications and do not wrap any code.  This means that they won't yield anything meaningful and they can't be timed.

--- a/lib/graphql/persisted_queries.rb
+++ b/lib/graphql/persisted_queries.rb
@@ -21,6 +21,8 @@ module GraphQL
       error_handler = options.delete(:error_handler) || :default
       schema.configure_persisted_query_error_handler(error_handler)
 
+      schema.persisted_queries_tracing_enabled = options.delete(:tracing)
+
       store = options.delete(:store) || :memory
       schema.configure_persisted_query_store(store, options)
     end

--- a/lib/graphql/persisted_queries/schema_patch.rb
+++ b/lib/graphql/persisted_queries/schema_patch.rb
@@ -49,8 +49,16 @@ module GraphQL
       end
 
       def multiplex(queries, **kwargs)
-        persisted_query_store.tracers = tracers if persisted_queries_tracing_enabled?
         MultiplexResolver.new(self, queries, kwargs).resolve
+      end
+
+      def tracer(name)
+        super.tap do
+          # Since tracers can be set before *and* after our plugin hooks in,
+          # we need to set tracers both when this plugin gets initialized
+          # and any time a tracer is added after initialization
+          persisted_query_store.tracers = tracers if persisted_queries_tracing_enabled?
+        end
       end
     end
   end

--- a/lib/graphql/persisted_queries/store_adapters/base_store_adapter.rb
+++ b/lib/graphql/persisted_queries/store_adapters/base_store_adapter.rb
@@ -14,11 +14,8 @@ module GraphQL
 
         def fetch_query(hash)
           fetch(hash).tap do |result|
-            if result
-              trace("fetch_query.cache_hit", adapter: @name)
-            else
-              trace("fetch_query.cache_miss", adapter: @name)
-            end
+            event = result ? "cache_hit" : "cache_miss"
+            trace("fetch_query.#{event}", adapter: @name)
           end
         end
 

--- a/lib/graphql/persisted_queries/store_adapters/base_store_adapter.rb
+++ b/lib/graphql/persisted_queries/store_adapters/base_store_adapter.rb
@@ -8,17 +8,33 @@ module GraphQL
         include GraphQL::Tracing::Traceable
         attr_writer :tracers
 
-        def initialize(_options); end
-
-        def fetch_query(_hash)
-          raise NotImplementedError
+        def initialize(_options)
+          @name = :base
         end
 
-        def save_query(_hash, _query)
-          raise NotImplementedError
+        def fetch_query(hash)
+          fetch(hash).tap do |result|
+            if result
+              trace("fetch_query.cache_hit", adapter: @name)
+            else
+              trace("fetch_query.cache_miss", adapter: @name)
+            end
+          end
+        end
+
+        def save_query(hash, query)
+          trace("save_query", adapter: @name) { save(hash, query) }
         end
 
         protected
+
+        def fetch(_hash)
+          raise NotImplementedError
+        end
+
+        def save(_hash, _query)
+          raise NotImplementedError
+        end
 
         def trace(key, metadata)
           if @tracers

--- a/lib/graphql/persisted_queries/store_adapters/base_store_adapter.rb
+++ b/lib/graphql/persisted_queries/store_adapters/base_store_adapter.rb
@@ -5,6 +5,9 @@ module GraphQL
     module StoreAdapters
       # Base class for all store adapters
       class BaseStoreAdapter
+        include GraphQL::Tracing::Traceable
+        attr_writer :tracers
+
         def initialize(_options); end
 
         def fetch_query(_hash)
@@ -13,6 +16,17 @@ module GraphQL
 
         def save_query(_hash, _query)
           raise NotImplementedError
+        end
+
+        protected
+
+        def trace(key, metadata)
+          if @tracers
+            key = "persisted_queries.#{key}"
+            block_given? ? super : super {}
+          elsif block_given?
+            yield
+          end
         end
       end
     end

--- a/lib/graphql/persisted_queries/store_adapters/memcached_store_adapter.rb
+++ b/lib/graphql/persisted_queries/store_adapters/memcached_store_adapter.rb
@@ -14,26 +14,17 @@ module GraphQL
           @dalli_proc = build_dalli_proc(dalli_client)
           @expiration = expiration || DEFAULT_EXPIRATION
           @namespace = namespace || DEFAULT_NAMESPACE
+          @name = :memcached
         end
 
-        def fetch_query(hash)
-          @dalli_proc.call do |dalli|
-            dalli.get(key_for(hash)).tap do |result|
-              if result
-                trace("fetch_query.cache_hit", adapter: :memcached)
-              else
-                trace("fetch_query.cache_miss", adapter: :memcached)
-              end
-            end
-          end
+        protected
+
+        def fetch(hash)
+          @dalli_proc.call { |dalli| dalli.get(key_for(hash)) }
         end
 
-        def save_query(hash, query)
-          @dalli_proc.call do |dalli|
-            trace("save_query", adapter: :memcached) do
-              dalli.set(key_for(hash), query, @expiration)
-            end
-          end
+        def save(hash, query)
+          @dalli_proc.call { |dalli| dalli.set(key_for(hash), query, @expiration) }
         end
 
         private

--- a/lib/graphql/persisted_queries/store_adapters/memory_store_adapter.rb
+++ b/lib/graphql/persisted_queries/store_adapters/memory_store_adapter.rb
@@ -10,11 +10,19 @@ module GraphQL
         end
 
         def fetch_query(hash)
-          @storage[hash]
+          @storage[hash].tap do |result|
+            if result
+              trace("fetch_query.cache_hit", adapter: :memory)
+            else
+              trace("fetch_query.cache_miss", adapter: :memory)
+            end
+          end
         end
 
         def save_query(hash, query)
-          @storage[hash] = query
+          trace("save_query", adapter: :memory) do
+            @storage[hash] = query
+          end
         end
       end
     end

--- a/lib/graphql/persisted_queries/store_adapters/memory_store_adapter.rb
+++ b/lib/graphql/persisted_queries/store_adapters/memory_store_adapter.rb
@@ -7,22 +7,17 @@ module GraphQL
       class MemoryStoreAdapter < BaseStoreAdapter
         def initialize(_options)
           @storage = {}
+          @name = :memory
         end
 
-        def fetch_query(hash)
-          @storage[hash].tap do |result|
-            if result
-              trace("fetch_query.cache_hit", adapter: :memory)
-            else
-              trace("fetch_query.cache_miss", adapter: :memory)
-            end
-          end
+        protected
+
+        def fetch(hash)
+          @storage[hash]
         end
 
-        def save_query(hash, query)
-          trace("save_query", adapter: :memory) do
-            @storage[hash] = query
-          end
+        def save(hash, query)
+          @storage[hash] = query
         end
       end
     end

--- a/lib/graphql/persisted_queries/store_adapters/redis_store_adapter.rb
+++ b/lib/graphql/persisted_queries/store_adapters/redis_store_adapter.rb
@@ -14,26 +14,17 @@ module GraphQL
           @redis_proc = build_redis_proc(redis_client)
           @expiration = expiration || DEFAULT_EXPIRATION
           @namespace = namespace || DEFAULT_NAMESPACE
+          @name = :redis
         end
 
-        def fetch_query(hash)
-          @redis_proc.call do |redis|
-            redis.get(key_for(hash)).tap do |result|
-              if result
-                trace("fetch_query.cache_hit", adapter: :redis)
-              else
-                trace("fetch_query.cache_miss", adapter: :redis)
-              end
-            end
-          end
+        protected
+
+        def fetch(hash)
+          @redis_proc.call { |redis| redis.get(key_for(hash)) }
         end
 
-        def save_query(hash, query)
-          @redis_proc.call do |redis|
-            trace("save_query", adapter: :redis) do
-              redis.set(key_for(hash), query, ex: @expiration)
-            end
-          end
+        def save(hash, query)
+          @redis_proc.call { |redis| redis.set(key_for(hash), query, ex: @expiration) }
         end
 
         private

--- a/lib/graphql/persisted_queries/store_adapters/redis_store_adapter.rb
+++ b/lib/graphql/persisted_queries/store_adapters/redis_store_adapter.rb
@@ -17,11 +17,23 @@ module GraphQL
         end
 
         def fetch_query(hash)
-          @redis_proc.call { |redis| redis.get(key_for(hash)) }
+          @redis_proc.call do |redis|
+            redis.get(key_for(hash)).tap do |result|
+              if result
+                trace("fetch_query.cache_hit", adapter: :redis)
+              else
+                trace("fetch_query.cache_miss", adapter: :redis)
+              end
+            end
+          end
         end
 
         def save_query(hash, query)
-          @redis_proc.call { |redis| redis.set(key_for(hash), query, ex: @expiration) }
+          @redis_proc.call do |redis|
+            trace("save_query", adapter: :redis) do
+              redis.set(key_for(hash), query, ex: @expiration)
+            end
+          end
         end
 
         private

--- a/lib/graphql/persisted_queries/store_adapters/redis_with_local_cache_store_adapter.rb
+++ b/lib/graphql/persisted_queries/store_adapters/redis_with_local_cache_store_adapter.rb
@@ -19,9 +19,20 @@ module GraphQL
             namespace: namespace
           )
           @memory_adapter = memory_adapter_class.new(nil)
+          @name = :redis_with_local_cache
         end
 
-        def fetch_query(hash)
+        # We don't need to implement our own traces for this adapter since the
+        # underlying adapters will emit the proper events for us.  However,
+        # since tracers can be defined at any time, we need to pass them through.
+        def tracers=(tracers)
+          @memory_adapter.tracers = tracers
+          @redis_adapter.tracers = tracers
+        end
+
+        protected
+
+        def fetch(hash)
           result = @memory_adapter.fetch_query(hash)
           result ||= begin
             inner_result = @redis_adapter.fetch_query(hash)
@@ -31,17 +42,9 @@ module GraphQL
           result
         end
 
-        def save_query(hash, query)
+        def save(hash, query)
           @redis_adapter.save_query(hash, query)
           @memory_adapter.save_query(hash, query)
-        end
-
-        # We don't need to implement our own traces for this adapter since the
-        # underlying adapters will emit the proper events for us.  However,
-        # since tracers can be defined at any time, we need to pass them through.
-        def tracers=(tracers)
-          @memory_adapter.tracers = tracers
-          @redis_adapter.tracers = tracers
         end
 
         private

--- a/lib/graphql/persisted_queries/store_adapters/redis_with_local_cache_store_adapter.rb
+++ b/lib/graphql/persisted_queries/store_adapters/redis_with_local_cache_store_adapter.rb
@@ -36,6 +36,14 @@ module GraphQL
           @memory_adapter.save_query(hash, query)
         end
 
+        # We don't need to implement our own traces for this adapter since the
+        # underlying adapters will emit the proper events for us.  However,
+        # since tracers can be defined at any time, we need to pass them through.
+        def tracers=(tracers)
+          @memory_adapter.tracers = tracers
+          @redis_adapter.tracers = tracers
+        end
+
         private
 
         attr_reader :redis_adapter, :memory_adapter

--- a/spec/graphql/persisted_queries/schema_patch_spec.rb
+++ b/spec/graphql/persisted_queries/schema_patch_spec.rb
@@ -14,24 +14,6 @@ RSpec.describe GraphQL::PersistedQueries::SchemaPatch do
     end
   end
 
-  Tracer = Class.new do
-    attr_reader :events
-
-    def initialize
-      clear!
-    end
-
-    def trace(key, value)
-      result = yield
-      @events[key] << { metadata: value, result: result }
-      result
-    end
-
-    def clear!
-      @events = Hash.new { |hash, key| hash[key] = [] }
-    end
-  end
-
   let(:query) { "query { someData }" }
 
   let(:sha256) { Digest::SHA256.hexdigest(query) }
@@ -40,7 +22,7 @@ RSpec.describe GraphQL::PersistedQueries::SchemaPatch do
     build_test_schema(error_handler: ErrorHandler.new({}))
   end
 
-  let(:tracer) { Tracer.new }
+  let(:tracer) { TestTracer.new }
 
   let(:schema_with_tracer) do
     build_test_schema(error_handler: ErrorHandler.new({}), tracing: true, tracer: tracer)

--- a/spec/graphql/persisted_queries/store_adapters/base_store_adapter_spec.rb
+++ b/spec/graphql/persisted_queries/store_adapters/base_store_adapter_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "redis"
+require "connection_pool"
+
+RSpec.describe GraphQL::PersistedQueries::StoreAdapters::BaseStoreAdapter do
+  TestableStoreAdapter = Class.new(described_class) do
+    def initialize(options)
+      @name = :testable
+      @storage = options[:storage]
+    end
+
+    def fetch(hash)
+      @storage[hash]
+    end
+
+    def save(hash, query)
+      @storage[hash] = query
+    end
+  end
+
+  let(:storage) { {} }
+  subject { TestableStoreAdapter.new(storage: storage) }
+
+  describe "tracing events" do
+    let(:tracer) { TestTracer.new }
+    before do
+      subject.tracers = [tracer]
+    end
+
+    it "emits a cache_miss event", focus: true do
+      storage["greenday"] = nil
+      subject.fetch_query("greenday")
+
+      expect(tracer.events).to eq(
+        "persisted_queries.fetch_query.cache_miss" => [{
+          metadata: { adapter: :testable },
+          result: nil
+        }]
+      )
+    end
+
+    it "emits a cache_hit event", focus: true do
+      storage["greenday"] = "welcome-to-paradise"
+      subject.fetch_query("greenday")
+
+      expect(tracer.events).to eq(
+        "persisted_queries.fetch_query.cache_hit" => [{
+          metadata: { adapter: :testable },
+          result: nil
+        }]
+      )
+    end
+
+    it "emits a save_query event", focus: true do
+      subject.save_query("greenday", "welcome-to-paradise")
+
+      expect(tracer.events).to eq(
+        "persisted_queries.save_query" => [{
+          metadata: { adapter: :testable },
+          result: "welcome-to-paradise"
+        }]
+      )
+    end
+  end
+end

--- a/spec/graphql/support/test_schema.rb
+++ b/spec/graphql/support/test_schema.rb
@@ -2,8 +2,10 @@
 
 # rubocop:disable Metrics/MethodLength
 def build_test_schema(options = {})
+  test_tracer = options.delete(:tracer)
   schema = Class.new(GraphQL::Schema) do
     use GraphQL::PersistedQueries, options
+    tracer test_tracer if test_tracer
 
     query(
       Class.new(GraphQL::Schema::Object) do

--- a/spec/graphql/support/test_tracer.rb
+++ b/spec/graphql/support/test_tracer.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# TestTracer is used to collect events emitted through the tracing
+# system for testing purposes only
+class TestTracer
+  attr_reader :events
+
+  def initialize
+    clear!
+  end
+
+  def trace(key, value)
+    result = yield
+    @events[key] << { metadata: value, result: result }
+    result
+  end
+
+  def clear!
+    @events = Hash.new { |hash, key| hash[key] = [] }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@
 require "graphql"
 require "graphql/persisted_queries"
 require "graphql/support/test_schema"
+require "graphql/support/test_tracer"
 
 ENV["RAILS_ENV"] = "test"
 


### PR DESCRIPTION
Building off the implementation in #19 for the feature discussed in #18, this moves the tracing into the storage adapters so that they can be accurately tagged with the adapter name that triggered the event.

Also different from #19 is how some events (cache hit and cache miss) are traced with empty blocks so that they can simply emit things that happened, but don't have any code to wrap.  I'd love feedback on this.  It works well (we're using this experimental branch in production right now, though clients haven't fully adopted APQ yet) but it feels a bit awkward.  Like you mentioned before, this is an advanced feature so we may be able to deal with some awkwardness here.

This is also disabled behind a configuration flag, so by default it's essentially a no-op with essentially zero performance overhead.

I'm going to add a couple questions in code to clarify some things, but I think this is overall a better approach.  Let me know what you think and I'm happy to write up some docs (probably outside of the README for this?) and address any feedback.