### PR TITLE
Keep extensions in query context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- [PR#30](https://github.com/DmitryTsepelev/graphql-ruby-persisted_queries/pull/30) **BREAKING CHANGE** Move extenstions to the query context ([@DmitryTsepelev][])
+
 ## 0.5.1 (2020-03-18)
 
 - [PR#33](https://github.com/DmitryTsepelev/graphql-ruby-persisted_queries/pull/33) Support AST analyzers ([@DmitryTsepelev][])

--- a/README.md
+++ b/README.md
@@ -51,15 +51,16 @@ class GraphqlSchema < GraphQL::Schema
 end
 ```
 
-Pass `:extensions` argument to all calls of `GraphqlSchema#execute`, usually it happens in `GraphqlController`, `GraphqlChannel` and tests.
+Pass `:extensions` argument as part of a `context` to all calls of `GraphqlSchema#execute`, usually it happens in `GraphqlController`, `GraphqlChannel` and tests:
 
 ```ruby
 GraphqlSchema.execute(
   params[:query],
   variables: ensure_hash(params[:variables]),
-  context: {},
-  operation_name: params[:operationName],
-  extensions: ensure_hash(params[:extensions])
+  context: {
+    extensions: ensure_hash(params[:extensions])
+  },
+  operation_name: params[:operationName]
 )
 ```
 

--- a/docs/http_cache.md
+++ b/docs/http_cache.md
@@ -28,7 +28,14 @@ get "/graphql", to: "graphql#execute"
 Put the request object to the GraphQL context everywhere you execute GraphQL queries:
 
 ```ruby
-GraphqlSchema.execute(query, variables: variables, context: { request: request })
+GraphqlSchema.execute(
+  query,
+  variables: ensure_hash(params[:variables]),
+  context: {
+    extensions: ensure_hash(params[:extensions])
+    request: request
+  }
+)
 ```
 
 Turn the `verify_http_method` option when configuring the plugin to enforce using `POST` requests for performing mutations (otherwise the error `Mutations cannot be performed via HTTP GET` will be returned):

--- a/lib/graphql/persisted_queries/multiplex_resolver.rb
+++ b/lib/graphql/persisted_queries/multiplex_resolver.rb
@@ -29,7 +29,7 @@ module GraphQL
       end
 
       def resolve_persisted_query(query_params, pos)
-        extensions = query_params.delete(:extensions)
+        extensions = query_params.dig(:context, :extensions)
         return unless extensions
 
         query_params[:query] = Resolver.new(extensions, @schema).resolve(query_params[:query])

--- a/spec/graphql/persisted_queries/multiplex_resolver_spec.rb
+++ b/spec/graphql/persisted_queries/multiplex_resolver_spec.rb
@@ -14,8 +14,14 @@ RSpec.describe GraphQL::PersistedQueries::MultiplexResolver do
 
     let(:queries) do
       [
-        { query: query1, extensions: { "persistedQuery" => { "sha256Hash" => sha256_1 } } },
-        { query: query2, extensions: { "persistedQuery" => { "sha256Hash" => sha256_2 } } }
+        {
+          query: query1,
+          context: { extensions: { "persistedQuery" => { "sha256Hash" => sha256_1 } } }
+        },
+        {
+          query: query2,
+          context: { extensions: { "persistedQuery" => { "sha256Hash" => sha256_2 } } }
+        }
       ]
     end
 

--- a/spec/graphql/persisted_queries/schema_patch_spec.rb
+++ b/spec/graphql/persisted_queries/schema_patch_spec.rb
@@ -34,8 +34,12 @@ RSpec.describe GraphQL::PersistedQueries::SchemaPatch do
       selected_query = with_query ? query : nil
       tracer.clear! if with_tracer
 
-      current_schema.execute(selected_query,
-                             extensions: { "persistedQuery" => { "sha256Hash" => sha256 } })
+      current_schema.execute(
+        selected_query,
+        context: {
+          extensions: { "persistedQuery" => { "sha256Hash" => sha256 } }
+        }
+      )
     end
 
     subject(:response) { perform_request }
@@ -107,7 +111,8 @@ RSpec.describe GraphQL::PersistedQueries::SchemaPatch do
         # rubocop: disable Lint/HandleExceptions
         begin
           schema.execute(
-            query, extensions: { "persistedQuery" => { "sha256Hash" => sha256 } }
+            query,
+            context: { extensions: { "persistedQuery" => { "sha256Hash" => sha256 } } }
           )
         rescue RuntimeError
           # Ignore the expected error
@@ -126,7 +131,11 @@ RSpec.describe GraphQL::PersistedQueries::SchemaPatch do
       [
         {
           query: query,
-          extensions: { "persistedQuery" => { "sha256Hash" => Digest::SHA256.hexdigest(query) } }
+          context: {
+            extensions: {
+              "persistedQuery" => { "sha256Hash" => Digest::SHA256.hexdigest(query) }
+            }
+          }
         }
       ]
     end


### PR DESCRIPTION
As discussed in #25, it makes sense to keep extension param in the query context. I've made some changes and it works! However, it's a breaking change, so I believe we should either make a major release (since it's going to be a simple change) or perform a "soft" update (minor release with deprecation warning and full deprecation in the major release later). @JanStevens @bmorton what do you think?