### PR TITLE
return GraphQL::Query::Result when raise error

### DIFF
--- a/lib/graphql/persisted_queries/multiplex_resolver.rb
+++ b/lib/graphql/persisted_queries/multiplex_resolver.rb
@@ -34,7 +34,8 @@ module GraphQL
 
         query_params[:query] = Resolver.new(extensions, @schema).resolve(query_params[:query])
       rescue Resolver::NotFound, Resolver::WrongHash => e
-        results[pos] = { "errors" => [{ "message" => e.message }] }
+        values = { "errors" => [{ "message" => e.message }] }
+        results[pos] = GraphQL::Query::Result.new(query: query_params[:query], values: values)
       end
 
       def perform_multiplex


### PR DESCRIPTION
Normally GraphQL::Schema.execute expects GraphQL::Query::Result
However,If an error occurs, the result of GraphQL::Schema.execute will be hash because it returns Hash.

This Pull Request becomes return GraphQL::Query::Result even if an error occurs.
