### PR TITLE
fix args for GraphQL::Query::Result

### DIFF
--- a/lib/graphql/persisted_queries/multiplex_resolver.rb
+++ b/lib/graphql/persisted_queries/multiplex_resolver.rb
@@ -35,7 +35,7 @@ module GraphQL
         query_params[:query] = Resolver.new(extensions, @schema).resolve(query_params[:query])
       rescue Resolver::NotFound, Resolver::WrongHash => e
         values = { "errors" => [{ "message" => e.message }] }
-        results[pos] = GraphQL::Query::Result.new(query: query_params[:query], values: values)
+        results[pos] = GraphQL::Query::Result.new(query: GraphQL::Query.new(@schema, query_params[:query]), values: values)
       end
 
       def perform_multiplex


### PR DESCRIPTION
The fix for #34 was inadequate. I'm sorry.

[GraphQL::Result class delegates some methods to @query](https://github.com/rmosolgo/graphql-ruby/blob/master/lib/graphql/query/result.rb#L22)
so `@query` expects GraphQL::Query class instead of string or nil.
If `@query` is a string or nil, the method will call with an error as below

```rb
> result = TestSchema.execute(query, variables: variables, context: context, operation_name: operation_name)
=> #<GraphQL::Query::Result @query=... @to_h={"errors"=>[{"message"=>"PersistedQueryNotFound"}]}>
> result["errors"]
=> [{"message"=>"PersistedQueryNotFound"}]
> result. context
NoMethodError: undefined method `conteext' for #<GraphQL::Query::Result:0x00007f93cb9d9098>
```

