### PR TITLE
Fix deprecation warnings

### DIFF
--- a/lib/graphql/persisted_queries.rb
+++ b/lib/graphql/persisted_queries.rb
@@ -9,7 +9,7 @@ require "graphql/persisted_queries/builder_helpers"
 module GraphQL
   # Plugin definition
   module PersistedQueries
-    def self.use(schema_defn, options = {})
+    def self.use(schema_defn, **options)
       schema = schema_defn.is_a?(Class) ? schema_defn : schema_defn.target
       SchemaPatch.patch(schema)
 
@@ -23,7 +23,7 @@ module GraphQL
       schema.persisted_queries_tracing_enabled = options.delete(:tracing)
 
       store = options.delete(:store) || :memory
-      schema.configure_persisted_query_store(store, options)
+      schema.configure_persisted_query_store(store, **options)
     end
   end
 end

--- a/lib/graphql/persisted_queries/error_handlers.rb
+++ b/lib/graphql/persisted_queries/error_handlers.rb
@@ -7,13 +7,13 @@ module GraphQL
   module PersistedQueries
     # Contains factory methods for error handlers
     module ErrorHandlers
-      def self.build(handler, options = nil)
+      def self.build(handler, **options)
         if handler.is_a?(ErrorHandlers::BaseErrorHandler)
           handler
         elsif handler.is_a?(Proc)
           build_from_proc(handler)
         else
-          build_by_name(handler, options)
+          build_by_name(handler, **options)
         end
       end
 
@@ -25,8 +25,8 @@ module GraphQL
         proc
       end
 
-      def self.build_by_name(name, options)
-        const_get("#{BuilderHelpers.camelize(name)}ErrorHandler").new(options || {})
+      def self.build_by_name(name, **options)
+        const_get("#{BuilderHelpers.camelize(name)}ErrorHandler").new(**options)
       rescue NameError => e
         raise e.class, "Persisted query error handler for :#{name} haven't been found", e.backtrace
       end

--- a/lib/graphql/persisted_queries/error_handlers/base_error_handler.rb
+++ b/lib/graphql/persisted_queries/error_handlers/base_error_handler.rb
@@ -5,7 +5,7 @@ module GraphQL
     module ErrorHandlers
       # Base class for all error handlers
       class BaseErrorHandler
-        def initialize(_options); end
+        def initialize(**_options); end
 
         def call(_error)
           raise NotImplementedError

--- a/lib/graphql/persisted_queries/multiplex_resolver.rb
+++ b/lib/graphql/persisted_queries/multiplex_resolver.rb
@@ -4,7 +4,7 @@ module GraphQL
   module PersistedQueries
     # Resolves multiplex query
     class MultiplexResolver
-      def initialize(schema, queries, kwargs)
+      def initialize(schema, queries, **kwargs)
         @schema = schema
         @queries = queries
         @kwargs = kwargs
@@ -42,7 +42,7 @@ module GraphQL
       def perform_multiplex
         resolve_idx = (0...@queries.count).select { |i| results[i].nil? }
         multiplex_result = @schema.multiplex_original(
-          resolve_idx.map { |i| @queries.at(i) }, @kwargs
+          resolve_idx.map { |i| @queries.at(i) }, **@kwargs
         )
         resolve_idx.each_with_index { |res_i, mult_i| results[res_i] = multiplex_result[mult_i] }
       end

--- a/lib/graphql/persisted_queries/schema_patch.rb
+++ b/lib/graphql/persisted_queries/schema_patch.rb
@@ -19,8 +19,8 @@ module GraphQL
       attr_reader :persisted_query_store, :hash_generator_proc, :persisted_query_error_handler
       attr_writer :persisted_queries_tracing_enabled
 
-      def configure_persisted_query_store(store, options)
-        @persisted_query_store = StoreAdapters.build(store, options).tap do |adapter|
+      def configure_persisted_query_store(store, **options)
+        @persisted_query_store = StoreAdapters.build(store, **options).tap do |adapter|
           adapter.tracers = tracers if persisted_queries_tracing_enabled?
         end
       end
@@ -48,7 +48,7 @@ module GraphQL
       end
 
       def multiplex(queries, **kwargs)
-        MultiplexResolver.new(self, queries, kwargs).resolve
+        MultiplexResolver.new(self, queries, **kwargs).resolve
       end
 
       def tracer(name)

--- a/lib/graphql/persisted_queries/store_adapters.rb
+++ b/lib/graphql/persisted_queries/store_adapters.rb
@@ -10,16 +10,16 @@ module GraphQL
   module PersistedQueries
     # Contains factory methods for store adapters
     module StoreAdapters
-      def self.build(adapter, options = nil)
+      def self.build(adapter, **options)
         if adapter.is_a?(StoreAdapters::BaseStoreAdapter)
           adapter
         else
-          build_by_name(adapter, options)
+          build_by_name(adapter, **options)
         end
       end
 
-      def self.build_by_name(name, options)
-        const_get("#{BuilderHelpers.camelize(name)}StoreAdapter").new(options || {})
+      def self.build_by_name(name, **options)
+        const_get("#{BuilderHelpers.camelize(name)}StoreAdapter").new(**options)
       rescue NameError => e
         raise e.class, "Persisted query store adapter for :#{name} haven't been found", e.backtrace
       end

--- a/lib/graphql/persisted_queries/store_adapters/base_store_adapter.rb
+++ b/lib/graphql/persisted_queries/store_adapters/base_store_adapter.rb
@@ -8,7 +8,7 @@ module GraphQL
         include GraphQL::Tracing::Traceable
         attr_writer :tracers
 
-        def initialize(_options)
+        def initialize(**_options)
           @name = :base
         end
 

--- a/lib/graphql/persisted_queries/store_adapters/memcached_store_adapter.rb
+++ b/lib/graphql/persisted_queries/store_adapters/memcached_store_adapter.rb
@@ -35,7 +35,7 @@ module GraphQL
 
         def build_dalli_proc(dalli_client)
           if dalli_client.is_a?(Hash)
-            build_dalli_proc(MemcachedClientBuilder.new(dalli_client).build)
+            build_dalli_proc(MemcachedClientBuilder.new(**dalli_client).build)
           elsif dalli_client.is_a?(Proc)
             dalli_client
           elsif defined?(::Dalli::Client) && dalli_client.is_a?(::Dalli::Client)

--- a/lib/graphql/persisted_queries/store_adapters/memory_store_adapter.rb
+++ b/lib/graphql/persisted_queries/store_adapters/memory_store_adapter.rb
@@ -5,7 +5,7 @@ module GraphQL
     module StoreAdapters
       # Memory adapter for storing persisted queries
       class MemoryStoreAdapter < BaseStoreAdapter
-        def initialize(_options)
+        def initialize(**_options)
           @storage = {}
           @name = :memory
         end

--- a/spec/graphql/persisted_queries/error_handlers/default_error_handler_spec.rb
+++ b/spec/graphql/persisted_queries/error_handlers/default_error_handler_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 RSpec.describe GraphQL::PersistedQueries::ErrorHandlers::DefaultErrorHandler do
   let(:options) { {} }
-  subject { described_class.new(options) }
+  subject { described_class.new(**options) }
 
   describe "#call" do
     context "when passed an error" do

--- a/spec/graphql/persisted_queries/error_handlers_spec.rb
+++ b/spec/graphql/persisted_queries/error_handlers_spec.rb
@@ -4,12 +4,12 @@ require "spec_helper"
 
 RSpec.describe GraphQL::PersistedQueries::ErrorHandlers do
   describe ".build" do
-    let(:options) { nil }
-    subject { described_class.build(handler, options) }
+    let(:options) { {} }
+    subject { described_class.build(handler, **options) }
 
     context "when ErrorHandlers::BaseErrorHandler instance is passed" do
       let(:handler) do
-        GraphQL::PersistedQueries::ErrorHandlers::BaseErrorHandler.new(options)
+        GraphQL::PersistedQueries::ErrorHandlers::BaseErrorHandler.new(**options)
       end
 
       it { is_expected.to be(handler) }

--- a/spec/graphql/persisted_queries/multiplex_resolver_spec.rb
+++ b/spec/graphql/persisted_queries/multiplex_resolver_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe GraphQL::PersistedQueries::MultiplexResolver do
     let(:schema) { build_test_schema }
 
     subject do
-      described_class.new(schema, queries, {}).resolve
+      described_class.new(schema, queries).resolve
     end
 
     context "when cache is partially cold" do

--- a/spec/graphql/persisted_queries/resolver_spec.rb
+++ b/spec/graphql/persisted_queries/resolver_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe GraphQL::PersistedQueries::Resolver do
     let(:query_str) { query }
     let(:hash_generator_proc) { proc { |value| Digest::SHA256.hexdigest(value) } }
     let(:hash) { hash_generator_proc.call(query) }
-    let(:error_handler) { GraphQL::PersistedQueries::ErrorHandlers::DefaultErrorHandler.new({}) }
+    let(:error_handler) { GraphQL::PersistedQueries::ErrorHandlers::DefaultErrorHandler.new }
 
     let(:schema) do
       double("TestSchema").tap do |schema|

--- a/spec/graphql/persisted_queries/schema_patch_spec.rb
+++ b/spec/graphql/persisted_queries/schema_patch_spec.rb
@@ -19,13 +19,13 @@ RSpec.describe GraphQL::PersistedQueries::SchemaPatch do
   let(:sha256) { Digest::SHA256.hexdigest(query) }
 
   let(:schema) do
-    build_test_schema(error_handler: ErrorHandler.new({}))
+    build_test_schema(error_handler: ErrorHandler.new)
   end
 
   let(:tracer) { TestTracer.new }
 
   let(:schema_with_tracer) do
-    build_test_schema(error_handler: ErrorHandler.new({}), tracing: true, tracer: tracer)
+    build_test_schema(error_handler: ErrorHandler.new, tracing: true, tracer: tracer)
   end
 
   describe "#execute" do
@@ -99,11 +99,11 @@ RSpec.describe GraphQL::PersistedQueries::SchemaPatch do
 
       around do |test|
         original_store = schema.persisted_query_store
-        schema.configure_persisted_query_store(UnavailableStore.new({}), {})
+        schema.configure_persisted_query_store(UnavailableStore.new)
         begin
           test.run
         ensure
-          schema.configure_persisted_query_store(original_store, {})
+          schema.configure_persisted_query_store(original_store)
         end
       end
 

--- a/spec/graphql/persisted_queries/store_adapters/base_store_adapter_spec.rb
+++ b/spec/graphql/persisted_queries/store_adapters/base_store_adapter_spec.rb
@@ -7,7 +7,7 @@ require "connection_pool"
 
 RSpec.describe GraphQL::PersistedQueries::StoreAdapters::BaseStoreAdapter do
   TestableStoreAdapter = Class.new(described_class) do
-    def initialize(options)
+    def initialize(**options)
       @name = :testable
       @storage = options[:storage]
     end

--- a/spec/graphql/persisted_queries/store_adapters/memcached_store_adapter_spec.rb
+++ b/spec/graphql/persisted_queries/store_adapters/memcached_store_adapter_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 require "dalli"
 
 RSpec.describe GraphQL::PersistedQueries::StoreAdapters::MemcachedStoreAdapter do
-  subject { described_class.new(options) }
+  subject { described_class.new(**options) }
 
   let(:expiration) { nil }
   let(:namespace) { nil }

--- a/spec/graphql/persisted_queries/store_adapters/redis_client_builder_spec.rb
+++ b/spec/graphql/persisted_queries/store_adapters/redis_client_builder_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe GraphQL::PersistedQueries::StoreAdapters::RedisClientBuilder do
   describe "#initialize" do
     let(:options) { {} }
 
-    subject { described_class.new(options).build }
+    subject { described_class.new(**options).build }
 
     context "when redis_host, redis_port and redis_db_name are passed" do
       let(:options) do

--- a/spec/graphql/persisted_queries/store_adapters/redis_store_adapter_spec.rb
+++ b/spec/graphql/persisted_queries/store_adapters/redis_store_adapter_spec.rb
@@ -6,7 +6,7 @@ require "redis"
 require "connection_pool"
 
 RSpec.describe GraphQL::PersistedQueries::StoreAdapters::RedisStoreAdapter do
-  subject { described_class.new(options) }
+  subject { described_class.new(**options) }
 
   let(:expiration) { nil }
   let(:namespace) { nil }

--- a/spec/graphql/persisted_queries/store_adapters/redis_with_local_cache_store_adapter_spec.rb
+++ b/spec/graphql/persisted_queries/store_adapters/redis_with_local_cache_store_adapter_spec.rb
@@ -6,7 +6,7 @@ require "redis"
 require "connection_pool"
 
 RSpec.describe GraphQL::PersistedQueries::StoreAdapters::RedisWithLocalCacheStoreAdapter do
-  subject { described_class.new(options) }
+  subject { described_class.new(**options) }
 
   let(:redis_client) { { redis_url: "redis://127.0.0.3:8791/3" } }
   let(:mock_redis_adapter) { double("RedisStoreAdapterDouble") }

--- a/spec/graphql/persisted_queries/store_adapters_spec.rb
+++ b/spec/graphql/persisted_queries/store_adapters_spec.rb
@@ -4,12 +4,12 @@ require "spec_helper"
 
 RSpec.describe GraphQL::PersistedQueries::StoreAdapters do
   describe ".build" do
-    let(:options) { nil }
-    subject { described_class.build(adapter, options) }
+    let(:options) { {} }
+    subject { described_class.build(adapter, **options) }
 
     context "when StoreAdapters::BaseStoreAdapter instance is passed" do
       let(:adapter) do
-        GraphQL::PersistedQueries::StoreAdapters::MemoryStoreAdapter.new(options)
+        GraphQL::PersistedQueries::StoreAdapters::MemoryStoreAdapter.new(**options)
       end
 
       it { is_expected.to be(adapter) }

--- a/spec/graphql/support/test_schema.rb
+++ b/spec/graphql/support/test_schema.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 # rubocop:disable Metrics/MethodLength
-def build_test_schema(options = {})
+def build_test_schema(**options)
   test_tracer = options.delete(:tracer)
   schema = Class.new(GraphQL::Schema) do
-    use GraphQL::PersistedQueries, options
+    use GraphQL::PersistedQueries, **options
     tracer test_tracer if test_tracer
 
     query(


### PR DESCRIPTION
Fixes ruby 2.7 warnings for projects using this gem.

```
warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```
