### PR TITLE
Implement compiled queries

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -52,4 +52,4 @@ jobs:
         bundle update
     - name: Run RSpec
       run: |
-        bundle exec rake spec
+        bundle exec rake ci_specs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- [PR#39](https://github.com/DmitryTsepelev/graphql-ruby-persisted_queries/pull/39) Implement compiled queries  ([@DmitryTsepelev][])
+
 ## 1.1.1 (2020-12-03)
 
 - [PR#37](https://github.com/DmitryTsepelev/graphql-ruby-persisted_queries/pull/37) Fix deprecation warnings ([@rbviz][])

--- a/README.md
+++ b/README.md
@@ -65,6 +65,20 @@ GraphqlSchema.execute(
 
 You're all set!
 
+## Compiled queries (increases performance up to 2x!)
+
+When query arrives to the backend, GraphQL execution engine needs some time to _parse_ it and build the AST. In case of a huge query it might take [a lot](https://gist.github.com/DmitryTsepelev/36e290cf64b4ec0b18294d0a57fb26ff#file-1_result-md) of time. What if we cache the AST instead of a query text and skip parsing completely? The only thing you need to do is to turn `:compiled_queries` option on:
+
+```ruby
+class GraphqlSchema < GraphQL::Schema
+  use GraphQL::PersistedQueries, compiled_queries: true
+end
+```
+
+Using this option might make your endpoint up to 2x faster according to the [benchmark]().
+
+**Heads up!** This feature only works on `graphql-ruby` 1.12.0 or later, but I guess it might be backported.
+
 ## Advanced usage
 
 All the queries are stored in memory by default, but you can easily switch to another storage (e.g., _redis_:

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ class GraphqlSchema < GraphQL::Schema
 end
 ```
 
-Using this option might make your endpoint up to 2x faster according to the [benchmark]().
+Using this option might make your endpoint up to 2x faster according to the [benchmark](docs/compiled_queries_benchmark.md).
 
 **Heads up!** This feature only works on `graphql-ruby` 1.12.0 or later, but I guess it might be backported.
 

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,18 @@ require "rubocop/rake_task"
 RSpec::Core::RakeTask.new(:spec)
 RuboCop::RakeTask.new
 
-task default: [:rubocop, :spec]
+desc "Run specs for compiled queries"
+RSpec::Core::RakeTask.new("spec:compiled_queries") do |task|
+  task.pattern = "**/compiled_queries/**"
+  task.verbose = false
+end
+
+RSpec::Core::RakeTask.new("spec:without_compiled_queries") do |task|
+  task.exclude_pattern = "**/compiled_queries/**"
+  task.verbose = false
+end
+
+task ci_specs: ["spec:without_compiled_queries", "spec:compiled_queries"]
 
 task :bench_gql do
   cmd = %w[bundle exec ruby benchmark/plain_gql.rb]

--- a/Rakefile
+++ b/Rakefile
@@ -6,3 +6,20 @@ RSpec::Core::RakeTask.new(:spec)
 RuboCop::RakeTask.new
 
 task default: [:rubocop, :spec]
+
+task :bench_gql do
+  cmd = %w[bundle exec ruby benchmark/plain_gql.rb]
+  system(*cmd)
+end
+
+task :bench_pq do
+  cmd = %w[bundle exec ruby benchmark/persisted_queries.rb]
+  system(*cmd)
+end
+
+task :bench_compiled do
+  cmd = %w[bundle exec ruby benchmark/compiled_queries.rb]
+  system(*cmd)
+end
+
+task bench: [:bench_gql, :bench_pq, :bench_compiled]

--- a/benchmark/compiled_queries.rb
+++ b/benchmark/compiled_queries.rb
@@ -24,16 +24,16 @@ puts "Schema with compiled queries:"
 puts
 
 Benchmark.bm(28) do |x|
-  [0, 1].each do |nesting_level|
+  [false, true].each do |with_nested|
     FIELD_COUNTS.each do |field_count|
-      query = generate_query(field_count, nesting_level)
+      query = generate_query(field_count, with_nested)
       sha256 = Digest::SHA256.hexdigest(query)
 
       context = { extensions: { "persistedQuery" => { "sha256Hash" => sha256 } } }
       # warmup
       GraphqlSchema.execute(query, context: context)
 
-      x.report("#{field_count} fields, #{nesting_level} nested levels: ") do
+      x.report("#{field_count} fields#{" (nested)" if with_nested}") do
         GraphqlSchema.execute(query, context: context)
       end
     end

--- a/benchmark/compiled_queries.rb
+++ b/benchmark/compiled_queries.rb
@@ -1,0 +1,43 @@
+require "bundler/inline"
+
+gemfile do
+  source "https://rubygems.org"
+  gem "graphql", "1.12.4"
+end
+
+$:.push File.expand_path("../lib", __dir__)
+
+require "benchmark"
+require "graphql/persisted_queries"
+require_relative "helpers"
+
+FIELD_COUNTS = [10, 100, 200, 300]
+
+class GraphqlSchema < GraphQL::Schema
+  use GraphQL::PersistedQueries, compiled_queries: true
+
+  query QueryType
+end
+
+GraphqlSchema.to_definition
+
+puts
+puts "Schema with compiled queries:"
+puts
+
+Benchmark.bm(28) do |x|
+  [0, 1].each do |nesting_level|
+    FIELD_COUNTS.each do |field_count|
+      query = generate_query(field_count, nesting_level)
+      sha256 = Digest::SHA256.hexdigest(query)
+
+      context = { extensions: { "persistedQuery" => { "sha256Hash" => sha256 } } }
+      # warmup
+      GraphqlSchema.execute(query, context: context)
+
+      x.report("#{field_count} fields, #{nesting_level} nested levels: ") do
+        GraphqlSchema.execute(query, context: context)
+      end
+    end
+  end
+end

--- a/benchmark/compiled_queries.rb
+++ b/benchmark/compiled_queries.rb
@@ -11,8 +11,6 @@ require "benchmark"
 require "graphql/persisted_queries"
 require_relative "helpers"
 
-FIELD_COUNTS = [10, 100, 200, 300]
-
 class GraphqlSchema < GraphQL::Schema
   use GraphQL::PersistedQueries, compiled_queries: true
 

--- a/benchmark/helpers.rb
+++ b/benchmark/helpers.rb
@@ -1,0 +1,41 @@
+FIELD_COUNTS = [10, 100, 200, 300]
+
+def generate_fields(field_count, nesting_level, indent = 6)
+  fields = field_count.times.map do |i|
+    field = " " * indent + "field#{i+1}"
+    if nesting_level > 0
+      field += <<-gql
+\s{
+#{generate_fields(field_count, nesting_level - 1, indent + 2)}
+#{" " * indent}}
+      gql
+    end
+    field
+  end
+
+  fields.join("\n")
+end
+
+def generate_query(field_count, nesting_level)
+  <<-gql
+    query {
+#{generate_fields(field_count, nesting_level)}
+    }
+  gql
+end
+
+class LeafType < GraphQL::Schema::Object
+  FIELD_COUNTS.max.times do |i|
+    field "field#{i + 1}".to_sym, String, null: false, resolver_method: :resolve_field
+  end
+
+  def resolve_field; "value"; end
+end
+
+class QueryType < GraphQL::Schema::Object
+  FIELD_COUNTS.max.times do |i|
+    field "field#{i + 1}".to_sym, LeafType, null: false, resolver_method: :resolve_field
+  end
+
+  def resolve_field; end
+end

--- a/benchmark/helpers.rb
+++ b/benchmark/helpers.rb
@@ -1,4 +1,4 @@
-FIELD_COUNTS = [10, 100, 200, 300]
+FIELD_COUNTS = [10, 50, 100, 200, 300]
 
 def generate_fields(field_count, nesting_level, indent = 6)
   fields = field_count.times.map do |i|

--- a/benchmark/helpers.rb
+++ b/benchmark/helpers.rb
@@ -1,41 +1,31 @@
 FIELD_COUNTS = [10, 50, 100, 200, 300]
 
-def generate_fields(field_count, nesting_level, indent = 6)
+def generate_fields(field_count, with_nested)
   fields = field_count.times.map do |i|
-    field = " " * indent + "field#{i+1}"
-    if nesting_level > 0
-      field += <<-gql
-\s{
-#{generate_fields(field_count, nesting_level - 1, indent + 2)}
-#{" " * indent}}
-      gql
-    end
+    field = "field#{i+1}"
+    field += "\s{#{generate_fields(field_count, false)}}" if with_nested
     field
   end
 
   fields.join("\n")
 end
 
-def generate_query(field_count, nesting_level)
+def generate_query(field_count, with_nested)
   <<-gql
     query {
-#{generate_fields(field_count, nesting_level)}
+      #{generate_fields(field_count, with_nested)}
     }
   gql
 end
 
-class LeafType < GraphQL::Schema::Object
+class ChildType < GraphQL::Schema::Object
   FIELD_COUNTS.max.times do |i|
-    field "field#{i + 1}".to_sym, String, null: false, resolver_method: :resolve_field
+    field "field#{i + 1}".to_sym, String, null: false, method: :itself
   end
-
-  def resolve_field; "value"; end
 end
 
 class QueryType < GraphQL::Schema::Object
   FIELD_COUNTS.max.times do |i|
-    field "field#{i + 1}".to_sym, LeafType, null: false, resolver_method: :resolve_field
+    field "field#{i + 1}".to_sym, ChildType, null: false, method: :itself
   end
-
-  def resolve_field; end
 end

--- a/benchmark/persisted_queries.rb
+++ b/benchmark/persisted_queries.rb
@@ -1,0 +1,41 @@
+require "bundler/inline"
+
+gemfile do
+  source "https://rubygems.org"
+  gem "graphql", "1.12.4"
+end
+
+$:.push File.expand_path("../lib", __dir__)
+
+require "benchmark"
+require "graphql/persisted_queries"
+require_relative "helpers"
+
+class GraphqlSchema < GraphQL::Schema
+  use GraphQL::PersistedQueries
+
+  query QueryType
+end
+
+GraphqlSchema.to_definition
+
+puts
+puts "Schema with persisted queries:"
+puts
+
+Benchmark.bm(28) do |x|
+  [0, 1].each do |nesting_level|
+    FIELD_COUNTS.each do |field_count|
+      query = generate_query(field_count, nesting_level)
+      sha256 = Digest::SHA256.hexdigest(query)
+      context = { extensions: { "persistedQuery" => { "sha256Hash" => sha256 } } }
+
+      # warmup
+      GraphqlSchema.execute(query, context: context)
+
+      x.report("#{field_count} fields, #{nesting_level} nested levels: ") do
+        GraphqlSchema.execute(query, context: context)
+      end
+    end
+  end
+end

--- a/benchmark/persisted_queries.rb
+++ b/benchmark/persisted_queries.rb
@@ -24,16 +24,16 @@ puts "Schema with persisted queries:"
 puts
 
 Benchmark.bm(28) do |x|
-  [0, 1].each do |nesting_level|
+  [false, true].each do |with_nested|
     FIELD_COUNTS.each do |field_count|
-      query = generate_query(field_count, nesting_level)
+      query = generate_query(field_count, with_nested)
       sha256 = Digest::SHA256.hexdigest(query)
       context = { extensions: { "persistedQuery" => { "sha256Hash" => sha256 } } }
 
       # warmup
       GraphqlSchema.execute(query, context: context)
 
-      x.report("#{field_count} fields, #{nesting_level} nested levels: ") do
+      x.report("#{field_count} fields#{" (nested)" if with_nested}") do
         GraphqlSchema.execute(query, context: context)
       end
     end

--- a/benchmark/plain_gql.rb
+++ b/benchmark/plain_gql.rb
@@ -1,0 +1,33 @@
+require "bundler/inline"
+
+gemfile do
+  source "https://rubygems.org"
+  gem "graphql", "1.12.4"
+end
+
+$:.push File.expand_path("../lib", __dir__)
+
+require "benchmark"
+require "graphql/persisted_queries"
+require_relative "helpers"
+
+class GraphqlSchema < GraphQL::Schema
+  query QueryType
+end
+
+GraphqlSchema.to_definition
+
+puts "Plain schema:"
+puts
+
+Benchmark.bm(28) do |x|
+  [0, 1].each do |nesting_level|
+    FIELD_COUNTS.each do |field_count|
+      query = generate_query(field_count, nesting_level)
+
+      x.report("#{field_count} fields, #{nesting_level} nested levels: ") do
+        GraphqlSchema.execute(query)
+      end
+    end
+  end
+end

--- a/benchmark/plain_gql.rb
+++ b/benchmark/plain_gql.rb
@@ -21,11 +21,11 @@ puts "Plain schema:"
 puts
 
 Benchmark.bm(28) do |x|
-  [0, 1].each do |nesting_level|
+  [false, true].each do |with_nested|
     FIELD_COUNTS.each do |field_count|
-      query = generate_query(field_count, nesting_level)
+      query = generate_query(field_count, with_nested)
 
-      x.report("#{field_count} fields, #{nesting_level} nested levels: ") do
+      x.report("#{field_count} fields#{" (nested)" if with_nested}") do
         GraphqlSchema.execute(query)
       end
     end

--- a/docs/compiled_queries_benchmark.md
+++ b/docs/compiled_queries_benchmark.md
@@ -1,0 +1,75 @@
+# Compiled queries benchmarks
+
+The name of benchmark consists of a field count and optional "nested" label. In case of non–nested one we just generate a query with that field count, e.g. `2 fields` means:
+
+```gql
+query {
+  field1
+  field2
+}
+```
+
+In case of "nested" benchmark we also put a list of fields to each top–level field, e.g. `2 fields (nested)` means:
+
+```gql
+query {
+  field1 {
+    field1
+    field2
+  }
+  field2 {
+    field1
+    field2
+  }
+}
+```
+
+Field resolver just returns a string, so real–world tests might be way slower because of IO.
+
+Here are the results:
+
+```
+Plain schema:
+
+                                   user     system      total        real
+10 fields                      0.001061   0.000039   0.001100 (  0.001114)
+50 fields                      0.001658   0.000003   0.001661 (  0.001661)
+100 fields                     0.004587   0.000026   0.004613 (  0.004614)
+200 fields                     0.006447   0.000016   0.006463 (  0.006476)
+300 fields                     0.024493   0.000073   0.024566 (  0.024614)
+10 fields (nested)             0.003061   0.000043   0.003104 (  0.003109)
+50 fields (nested)             0.056927   0.000995   0.057922 (  0.057997)
+100 fields (nested)            0.245235   0.001336   0.246571 (  0.246727)
+200 fields (nested)            0.974444   0.006531   0.980975 (  0.981810)
+300 fields (nested)            2.175855   0.012773   2.188628 (  2.190130)
+
+Schema with persisted queries:
+
+                                   user     system      total        real
+10 fields                      0.000606   0.000007   0.000613 (  0.000607)
+50 fields                      0.001855   0.000070   0.001925 (  0.001915)
+100 fields                     0.003239   0.000009   0.003248 (  0.003239)
+200 fields                     0.007542   0.000009   0.007551 (  0.007551)
+300 fields                     0.014975   0.000237   0.015212 (  0.015318)
+10 fields (nested)             0.002992   0.000068   0.003060 (  0.003049)
+50 fields (nested)             0.062314   0.000274   0.062588 (  0.062662)
+100 fields (nested)            0.256404   0.000865   0.257269 (  0.257419)
+200 fields (nested)            0.978408   0.007437   0.985845 (  0.986579)
+300 fields (nested)            2.263338   0.010994   2.274332 (  2.275967)
+
+Schema with compiled queries:
+
+                                   user     system      total        real
+10 fields                      0.000526   0.000009   0.000535 (  0.000530)
+50 fields                      0.001280   0.000012   0.001292 (  0.001280)
+100 fields                     0.002292   0.000004   0.002296 (  0.002286)
+200 fields                     0.005462   0.000001   0.005463 (  0.005463)
+300 fields                     0.014229   0.000121   0.014350 (  0.014348)
+10 fields (nested)             0.002027   0.000069   0.002096 (  0.002104)
+50 fields (nested)             0.029933   0.000087   0.030020 (  0.030040)
+100 fields (nested)            0.133933   0.000502   0.134435 (  0.134756)
+200 fields (nested)            0.495052   0.003545   0.498597 (  0.499452)
+300 fields (nested)            1.041463   0.005130   1.046593 (  1.047137)
+```
+
+Results gathered from my MacBook Pro Mid 2014 (2,5 GHz Quad-Core Intel Core i7, 16 GB 1600 MHz DDR3).

--- a/lib/graphql/persisted_queries.rb
+++ b/lib/graphql/persisted_queries.rb
@@ -1,10 +1,16 @@
 # frozen_string_literal: true
 
+require "graphql/persisted_queries/resolver_helpers"
+require "graphql/persisted_queries/errors"
 require "graphql/persisted_queries/error_handlers"
 require "graphql/persisted_queries/schema_patch"
 require "graphql/persisted_queries/store_adapters"
 require "graphql/persisted_queries/version"
 require "graphql/persisted_queries/builder_helpers"
+
+require "graphql/persisted_queries/compiled_queries/resolver"
+require "graphql/persisted_queries/compiled_queries/multiplex_patch"
+require "graphql/persisted_queries/compiled_queries/query_patch"
 
 module GraphQL
   # Plugin definition
@@ -32,8 +38,9 @@ module GraphQL
     # rubocop:enable Metrics/MethodLength
 
     def self.configure_compiled_queries
-      require "graphql/persisted_queries/compiled_queries/multiplex_patch"
-      require "graphql/persisted_queries/compiled_queries/query_patch"
+      if Gem::Dependency.new("graphql", "< 1.12.0").match?("graphql", GraphQL::VERSION)
+        raise ArgumentError, "compiled_queries are not supported for graphql-ruby < 1.12.0"
+      end
 
       GraphQL::Execution::Multiplex.singleton_class.prepend(
         GraphQL::PersistedQueries::CompiledQueries::MultiplexPatch

--- a/lib/graphql/persisted_queries.rb
+++ b/lib/graphql/persisted_queries.rb
@@ -36,10 +36,10 @@ module GraphQL
       require "graphql/persisted_queries/compiled_queries/query_patch"
 
       GraphQL::Execution::Multiplex.singleton_class.prepend(
-        GraphQL::CompiledQueries::MultiplexPatch
+        GraphQL::PersistedQueries::CompiledQueries::MultiplexPatch
       )
 
-      GraphQL::Query.prepend(GraphQL::CompiledQueries::QueryPatch)
+      GraphQL::Query.prepend(GraphQL::PersistedQueries::CompiledQueries::QueryPatch)
     end
   end
 end

--- a/lib/graphql/persisted_queries/compiled_queries/multiplex_patch.rb
+++ b/lib/graphql/persisted_queries/compiled_queries/multiplex_patch.rb
@@ -1,14 +1,28 @@
 # frozen_string_literal: true
 
 module GraphQL
-  module CompiledQueries
-    # Patches GraphQL::Execution::Multiplex to support compiled queries
-    module MultiplexPatch
-      def begin_query(query, multiplex)
-        if query.persisted_query_not_found?
-          query.context.errors << GraphQL::ExecutionError.new("PersistedQueryNotFound")
-          GraphQL::Execution::Multiplex::NO_OPERATION
-        else
+  module PersistedQueries
+    module CompiledQueries
+      # Patches GraphQL::Execution::Multiplex to support compiled queries
+      module MultiplexPatch
+        # 1.12.0-1.12.3
+        # def begin_query(query, multiplex)
+        #   if query.persisted_query_not_found?
+        #     query.context.errors << GraphQL::ExecutionError.new("PersistedQueryNotFound")
+        #     return GraphQL::Execution::Multiplex::NO_OPERATION
+        #   end
+        #
+        #   super
+        # end
+
+        # 1.12.4
+        def begin_query(results, idx, query, multiplex)
+          if query.persisted_query_not_found?
+            query.context.errors << GraphQL::ExecutionError.new("PersistedQueryNotFound")
+            results[idx] = NO_OPERATION
+            return
+          end
+
           super
         end
       end

--- a/lib/graphql/persisted_queries/compiled_queries/multiplex_patch.rb
+++ b/lib/graphql/persisted_queries/compiled_queries/multiplex_patch.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module GraphQL
+  module CompiledQueries
+    # Patches GraphQL::Execution::Multiplex to support compiled queries
+    module MultiplexPatch
+      def begin_query(query, multiplex)
+        if query.persisted_query_not_found?
+          query.context.errors << GraphQL::ExecutionError.new("PersistedQueryNotFound")
+          GraphQL::Execution::Multiplex::NO_OPERATION
+        else
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/graphql/persisted_queries/compiled_queries/query_patch.rb
+++ b/lib/graphql/persisted_queries/compiled_queries/query_patch.rb
@@ -11,10 +11,12 @@ module GraphQL
 
         def prepare_ast
           @document = resolver.fetch
-          @persisted_query_not_found = @document.nil? && query_string.nil?
+          not_loaded_document = @document.nil?
+
+          @persisted_query_not_found = not_loaded_document && query_string.nil?
 
           super.tap do
-            resolver.persist(query_string, @document) unless persisted_query_not_found?
+            resolver.persist(query_string, @document) if not_loaded_document && query_string
           end
         end
 

--- a/lib/graphql/persisted_queries/compiled_queries/query_patch.rb
+++ b/lib/graphql/persisted_queries/compiled_queries/query_patch.rb
@@ -10,6 +10,8 @@ module GraphQL
         end
 
         def prepare_ast
+          return super unless @context[:extensions]
+
           @document = resolver.fetch
           not_loaded_document = @document.nil?
 

--- a/lib/graphql/persisted_queries/compiled_queries/query_patch.rb
+++ b/lib/graphql/persisted_queries/compiled_queries/query_patch.rb
@@ -1,42 +1,45 @@
 # frozen_string_literal: true
 
 module GraphQL
-  module CompiledQueries
-    # Patches GraphQL::Query to support compiled queries
-    module QueryPatch
-      def persisted_query_not_found?
-        @persisted_query_not_found
-      end
-
-      def prepare_ast
-        try_fetch_query if persisted_query_hash
-        super.tap { persist_compiled_query }
-      end
-
-      private
-
-      def try_fetch_query
-        compiled_query = @schema.persisted_query_store.fetch_query(
-          persisted_query_hash, compiled_query: true
-        )
-
-        if compiled_query
-          @document = Marshal.load(compiled_query) # rubocop:disable Security/MarshalLoad
-        else
-          @persisted_query_not_found = query_string.nil?
+  module PersistedQueries
+    module CompiledQueries
+      # Patches GraphQL::Query to support compiled queries
+      module QueryPatch
+        def persisted_query_not_found?
+          @persisted_query_not_found
         end
-      end
 
-      def persist_compiled_query
-        return if persisted_query_hash.nil? || persisted_query_not_found?
+        def prepare_ast
+          try_fetch_query if persisted_query_hash
+          super.tap { persist_compiled_query }
+        end
 
-        @schema.persisted_query_store.save_query(
-          persisted_query_hash, Marshal.dump(@document), compiled_query: true
-        )
-      end
+        private
 
-      def persisted_query_hash
-        @persisted_query_hash ||= (@context[:extensions] || {}).dig("persistedQuery", "sha256Hash")
+        def try_fetch_query
+          compiled_query = @schema.persisted_query_store.fetch_query(
+            persisted_query_hash, compiled_query: true
+          )
+
+          if compiled_query
+            @document = Marshal.load(compiled_query) # rubocop:disable Security/MarshalLoad
+          else
+            @persisted_query_not_found = query_string.nil?
+          end
+        end
+
+        def persist_compiled_query
+          return if persisted_query_hash.nil? || persisted_query_not_found?
+
+          @schema.persisted_query_store.save_query(
+            persisted_query_hash, Marshal.dump(@document), compiled_query: true
+          )
+        end
+
+        def persisted_query_hash
+          @persisted_query_hash ||=
+            (@context[:extensions] || {}).dig("persistedQuery", "sha256Hash")
+        end
       end
     end
   end

--- a/lib/graphql/persisted_queries/compiled_queries/query_patch.rb
+++ b/lib/graphql/persisted_queries/compiled_queries/query_patch.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module GraphQL
+  module CompiledQueries
+    # Patches GraphQL::Query to support compiled queries
+    module QueryPatch
+      def persisted_query_not_found?
+        @persisted_query_not_found
+      end
+
+      def prepare_ast
+        try_fetch_query if persisted_query_hash
+        super.tap { persist_compiled_query }
+      end
+
+      private
+
+      def try_fetch_query
+        compiled_query = @schema.persisted_query_store.fetch_query(
+          persisted_query_hash, compiled_query: true
+        )
+
+        if compiled_query
+          @document = Marshal.load(compiled_query) # rubocop:disable Security/MarshalLoad
+        else
+          @persisted_query_not_found = query_string.nil?
+        end
+      end
+
+      def persist_compiled_query
+        return if persisted_query_hash.nil? || persisted_query_not_found?
+
+        @schema.persisted_query_store.save_query(
+          persisted_query_hash, Marshal.dump(@document), compiled_query: true
+        )
+      end
+
+      def persisted_query_hash
+        @persisted_query_hash ||= (@context[:extensions] || {}).dig("persistedQuery", "sha256Hash")
+      end
+    end
+  end
+end

--- a/lib/graphql/persisted_queries/compiled_queries/resolver.rb
+++ b/lib/graphql/persisted_queries/compiled_queries/resolver.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module GraphQL
+  module PersistedQueries
+    module CompiledQueries
+      # Fetches and persists compiled query
+      class Resolver
+        include GraphQL::PersistedQueries::ResolverHelpers
+
+        def initialize(schema, extensions)
+          @schema = schema
+          @extensions = extensions
+        end
+
+        def fetch
+          return if hash.nil?
+
+          with_error_handling do
+            compiled_query = @schema.persisted_query_store.fetch_query(hash, compiled_query: true)
+            Marshal.load(compiled_query) if compiled_query # rubocop:disable Security/MarshalLoad
+          end
+        end
+
+        def persist(query_string, compiled_query)
+          return if hash.nil?
+
+          validate_hash!(query_string)
+
+          with_error_handling do
+            @schema.persisted_query_store.save_query(
+              hash, Marshal.dump(compiled_query), compiled_query: true
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/graphql/persisted_queries/errors.rb
+++ b/lib/graphql/persisted_queries/errors.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module GraphQL
+  module PersistedQueries
+    # Raised when persisted query is not found in the storage
+    class NotFound < StandardError
+      def message
+        "PersistedQueryNotFound"
+      end
+    end
+
+    # Raised when provided hash is not matched with query
+    class WrongHash < StandardError
+      def message
+        "Wrong hash was passed"
+      end
+    end
+  end
+end

--- a/lib/graphql/persisted_queries/multiplex_resolver.rb
+++ b/lib/graphql/persisted_queries/multiplex_resolver.rb
@@ -33,7 +33,7 @@ module GraphQL
         return unless extensions
 
         query_params[:query] = Resolver.new(extensions, @schema).resolve(query_params[:query])
-      rescue Resolver::NotFound, Resolver::WrongHash => e
+      rescue GraphQL::PersistedQueries::NotFound, GraphQL::PersistedQueries::WrongHash => e
         values = { "errors" => [{ "message" => e.message }] }
         query = GraphQL::Query.new(@schema, query_params[:query])
         results[pos] = GraphQL::Query::Result.new(query: query, values: values)

--- a/lib/graphql/persisted_queries/resolver.rb
+++ b/lib/graphql/persisted_queries/resolver.rb
@@ -4,54 +4,32 @@ module GraphQL
   module PersistedQueries
     # Fetches or stores query string in the storage
     class Resolver
-      # Raised when persisted query is not found in the storage
-      class NotFound < StandardError
-        def message
-          "PersistedQueryNotFound"
-        end
-      end
-
-      # Raised when provided hash is not matched with query
-      class WrongHash < StandardError
-        def message
-          "Wrong hash was passed"
-        end
-      end
+      include GraphQL::PersistedQueries::ResolverHelpers
 
       def initialize(extensions, schema)
         @extensions = extensions
         @schema = schema
       end
 
-      def resolve(query_str)
-        return query_str if hash.nil?
+      def resolve(query_string)
+        return query_string if hash.nil?
 
-        if query_str
-          persist_query(query_str)
+        if query_string
+          persist_query(query_string)
         else
-          query_str = with_error_handling { @schema.persisted_query_store.fetch_query(hash) }
-          raise NotFound if query_str.nil?
+          query_string = with_error_handling { @schema.persisted_query_store.fetch_query(hash) }
+          raise GraphQL::PersistedQueries::NotFound if query_string.nil?
         end
 
-        query_str
+        query_string
       end
 
       private
 
-      def with_error_handling
-        yield
-      rescue StandardError => e
-        @schema.persisted_query_error_handler.call(e)
-      end
+      def persist_query(query_string)
+        validate_hash!(query_string)
 
-      def persist_query(query_str)
-        raise WrongHash if @schema.hash_generator_proc.call(query_str) != hash
-
-        with_error_handling { @schema.persisted_query_store.save_query(hash, query_str) }
-      end
-
-      def hash
-        @hash ||= @extensions.dig("persistedQuery", "sha256Hash")
+        with_error_handling { @schema.persisted_query_store.save_query(hash, query_string) }
       end
     end
   end

--- a/lib/graphql/persisted_queries/resolver_helpers.rb
+++ b/lib/graphql/persisted_queries/resolver_helpers.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module GraphQL
+  module PersistedQueries
+    # Helper functions for resolvers
+    module ResolverHelpers
+      module_function
+
+      def with_error_handling
+        yield
+      rescue StandardError => e
+        @schema.persisted_query_error_handler.call(e)
+      end
+
+      def validate_hash!(query_string)
+        return if @schema.hash_generator_proc.call(query_string) == hash
+
+        raise GraphQL::PersistedQueries::WrongHash
+      end
+
+      def hash
+        @hash ||= @extensions.dig("persistedQuery", "sha256Hash")
+      end
+    end
+  end
+end

--- a/lib/graphql/persisted_queries/store_adapters/base_store_adapter.rb
+++ b/lib/graphql/persisted_queries/store_adapters/base_store_adapter.rb
@@ -48,7 +48,8 @@ module GraphQL
         private
 
         def build_key(hash, compiled_query)
-          compiled_query ? "compiled:#{hash}" : hash
+          key = "#{RUBY_ENGINE}-#{RUBY_VERSION}:#{GraphQL::VERSION}:#{hash}"
+          compiled_query ? "compiled:#{key}" : key
         end
       end
     end

--- a/lib/graphql/persisted_queries/store_adapters/base_store_adapter.rb
+++ b/lib/graphql/persisted_queries/store_adapters/base_store_adapter.rb
@@ -12,15 +12,17 @@ module GraphQL
           @name = :base
         end
 
-        def fetch_query(hash)
-          fetch(hash).tap do |result|
+        def fetch_query(hash, compiled_query: false)
+          key = build_key(hash, compiled_query)
+          fetch(key).tap do |result|
             event = result ? "cache_hit" : "cache_miss"
             trace("fetch_query.#{event}", adapter: @name)
           end
         end
 
-        def save_query(hash, query)
-          trace("save_query", adapter: @name) { save(hash, query) }
+        def save_query(hash, query, compiled_query: false)
+          key = build_key(hash, compiled_query)
+          trace("save_query", adapter: @name) { save(key, query) }
         end
 
         protected
@@ -40,6 +42,12 @@ module GraphQL
           elsif block_given?
             yield
           end
+        end
+
+        private
+
+        def build_key(hash, compiled_query)
+          compiled_query ? "compiled:#{hash}" : hash
         end
       end
     end

--- a/lib/graphql/persisted_queries/store_adapters/base_store_adapter.rb
+++ b/lib/graphql/persisted_queries/store_adapters/base_store_adapter.rb
@@ -14,6 +14,7 @@ module GraphQL
 
         def fetch_query(hash, compiled_query: false)
           key = build_key(hash, compiled_query)
+
           fetch(key).tap do |result|
             event = result ? "cache_hit" : "cache_miss"
             trace("fetch_query.#{event}", adapter: @name)

--- a/spec/graphql/persisted_queries/compiled_queries/multiplex_patch_spec.rb
+++ b/spec/graphql/persisted_queries/compiled_queries/multiplex_patch_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "digest"
+
+RSpec.describe GraphQL::PersistedQueries::CompiledQueries::MultiplexPatch do
+  if Gem::Dependency.new("graphql", "< 1.12.0").match?("graphql", GraphQL::VERSION)
+    it "raises error" do
+      expect { build_test_schema(compiled_queries: true) }.to raise_error(
+        ArgumentError, "compiled_queries are not supported for graphql-ruby < 1.12.0"
+      )
+    end
+  else
+    let(:query_string_1) { "query { someData }" }
+    let(:query_string_2) { "query { someOtherData }" }
+
+    let(:query1) { query_string_1 }
+    let(:query2) { query_string_2 }
+
+    let(:sha256_1) { Digest::SHA256.hexdigest(query_string_1) }
+    let(:sha256_2) { Digest::SHA256.hexdigest(query_string_2) }
+
+    let(:queries) do
+      [
+        {
+          query: query1,
+          context: { extensions: { "persistedQuery" => { "sha256Hash" => sha256_1 } } }
+        },
+        {
+          query: query2,
+          context: { extensions: { "persistedQuery" => { "sha256Hash" => sha256_2 } } }
+        }
+      ]
+    end
+
+    let(:schema) { build_test_schema(compiled_queries: true) }
+
+    subject do
+      schema.multiplex(queries).map(&:to_h)
+    end
+
+    context "when cache is partially cold" do
+      let(:query1) { nil }
+
+      it "returns error and data" do
+        expect(subject).to eq(
+          [
+            { "errors" => [{ "message" => "PersistedQueryNotFound" }] },
+            { "data" => { "someOtherData" => "some other value" } }
+          ]
+        )
+      end
+    end
+
+    context "when cache is cold" do
+      let(:query1) { nil }
+      let(:query2) { nil }
+
+      it "returns errors" do
+        expect(subject).to eq(
+          [
+            { "errors" => [{ "message" => "PersistedQueryNotFound" }] },
+            { "errors" => [{ "message" => "PersistedQueryNotFound" }] }
+          ]
+        )
+      end
+    end
+
+    context "when cache is warm" do
+      it "returns data" do
+        expect(subject).to eq(
+          [
+            { "data" => { "someData" => "some value" } },
+            { "data" => { "someOtherData" => "some other value" } }
+          ]
+        )
+      end
+    end
+  end
+end

--- a/spec/graphql/persisted_queries/compiled_queries/multiplex_patch_spec.rb
+++ b/spec/graphql/persisted_queries/compiled_queries/multiplex_patch_spec.rb
@@ -12,69 +12,165 @@ RSpec.describe GraphQL::PersistedQueries::CompiledQueries::MultiplexPatch do
       )
     end
   else
-    let(:query_string_1) { "query { someData }" }
-    let(:query_string_2) { "query { someOtherData }" }
-
-    let(:query1) { query_string_1 }
-    let(:query2) { query_string_2 }
-
-    let(:sha256_1) { Digest::SHA256.hexdigest(query_string_1) }
-    let(:sha256_2) { Digest::SHA256.hexdigest(query_string_2) }
-
-    let(:queries) do
-      [
-        {
-          query: query1,
-          context: { extensions: { "persistedQuery" => { "sha256Hash" => sha256_1 } } }
-        },
-        {
-          query: query2,
-          context: { extensions: { "persistedQuery" => { "sha256Hash" => sha256_2 } } }
-        }
-      ]
-    end
-
     let(:schema) { build_test_schema(compiled_queries: true) }
 
-    subject do
-      schema.multiplex(queries).map(&:to_h)
-    end
+    describe "#execute" do
+      let(:query_string) { "query { someData }" }
+      let(:query) { query_string }
+      let(:sha256) { Digest::SHA256.hexdigest(query_string) }
+      let(:context) { { extensions: { "persistedQuery" => { "sha256Hash" => sha256 } } } }
 
-    context "when cache is partially cold" do
-      let(:query1) { nil }
+      subject do
+        schema.execute(query, context: context).to_h
+      end
 
-      it "returns error and data" do
-        expect(subject).to eq(
-          [
-            { "errors" => [{ "message" => "PersistedQueryNotFound" }] },
-            { "data" => { "someOtherData" => "some other value" } }
-          ]
-        )
+      before do
+        allow(GraphQL).to receive(:parse).and_call_original
+        allow(schema.persisted_query_store).to receive(:save_query).and_call_original
+      end
+
+      context "when query is not passed" do
+        let(:query) { nil }
+
+        it "returns error" do
+          expect(subject).to eq("errors" => [{ "message" => "PersistedQueryNotFound" }])
+        end
+
+        it "not calls GraphQL.parse" do
+          subject
+          expect(GraphQL).not_to have_received(:parse)
+        end
+
+        it "not persists query" do
+          subject
+          expect(schema.persisted_query_store).not_to have_received(:save_query)
+        end
+
+        context "when cache is warm" do
+          before do
+            schema.execute(query_string, context: context)
+          end
+
+          it "returns data" do
+            expect(subject).to eq("data" => { "someData" => "some value" })
+          end
+
+          it "not calls GraphQL.parse" do
+            expect(GraphQL).to have_received(:parse).once
+            subject
+            expect(GraphQL).to have_received(:parse).once
+          end
+        end
+      end
+
+      context "when query is passed" do
+        it "returns data" do
+          expect(subject).to eq("data" => { "someData" => "some value" })
+        end
+
+        it "calls GraphQL.parse" do
+          subject
+          expect(GraphQL).to have_received(:parse)
+        end
+
+        it "persists query" do
+          subject
+          expect(schema.persisted_query_store).to have_received(:save_query)
+        end
+
+        context "when cache is warm" do
+          before do
+            schema.execute(query_string, context: context)
+          end
+
+          it "returns data" do
+            expect(subject).to eq("data" => { "someData" => "some value" })
+          end
+
+          it "not persists query" do
+            expect(schema.persisted_query_store).to have_received(:save_query).once
+            subject
+            expect(schema.persisted_query_store).to have_received(:save_query).once
+          end
+
+          it "not calls GraphQL.parse" do
+            expect(GraphQL).to have_received(:parse).once
+            subject
+            expect(GraphQL).to have_received(:parse).once
+          end
+
+          it "not persists query" do
+            expect(schema.persisted_query_store).to have_received(:save_query).once
+            subject
+            expect(schema.persisted_query_store).to have_received(:save_query).once
+          end
+        end
       end
     end
 
-    context "when cache is cold" do
-      let(:query1) { nil }
-      let(:query2) { nil }
+    describe "#multiplex" do
+      let(:query_string_1) { "query { someData }" }
+      let(:query_string_2) { "query { someOtherData }" }
 
-      it "returns errors" do
-        expect(subject).to eq(
-          [
-            { "errors" => [{ "message" => "PersistedQueryNotFound" }] },
-            { "errors" => [{ "message" => "PersistedQueryNotFound" }] }
-          ]
-        )
+      let(:query1) { query_string_1 }
+      let(:query2) { query_string_2 }
+
+      let(:sha256_1) { Digest::SHA256.hexdigest(query_string_1) }
+      let(:sha256_2) { Digest::SHA256.hexdigest(query_string_2) }
+
+      let(:queries) do
+        [
+          {
+            query: query1,
+            context: { extensions: { "persistedQuery" => { "sha256Hash" => sha256_1 } } }
+          },
+          {
+            query: query2,
+            context: { extensions: { "persistedQuery" => { "sha256Hash" => sha256_2 } } }
+          }
+        ]
       end
-    end
 
-    context "when cache is warm" do
-      it "returns data" do
-        expect(subject).to eq(
-          [
-            { "data" => { "someData" => "some value" } },
-            { "data" => { "someOtherData" => "some other value" } }
-          ]
-        )
+      subject do
+        schema.multiplex(queries).map(&:to_h)
+      end
+
+      context "when all queries are not passed" do
+        let(:query1) { nil }
+        let(:query2) { nil }
+
+        it "returns errors" do
+          expect(subject).to eq(
+            [
+              { "errors" => [{ "message" => "PersistedQueryNotFound" }] },
+              { "errors" => [{ "message" => "PersistedQueryNotFound" }] }
+            ]
+          )
+        end
+      end
+
+      context "when one query is not passed" do
+        let(:query1) { nil }
+
+        it "returns error and data" do
+          expect(subject).to eq(
+            [
+              { "errors" => [{ "message" => "PersistedQueryNotFound" }] },
+              { "data" => { "someOtherData" => "some other value" } }
+            ]
+          )
+        end
+      end
+
+      context "when all queries are passed" do
+        it "returns data" do
+          expect(subject).to eq(
+            [
+              { "data" => { "someData" => "some value" } },
+              { "data" => { "someOtherData" => "some other value" } }
+            ]
+          )
+        end
       end
     end
   end

--- a/spec/graphql/persisted_queries/compiled_queries/resolver_spec.rb
+++ b/spec/graphql/persisted_queries/compiled_queries/resolver_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe GraphQL::PersistedQueries::CompiledQueries::Resolver do
+  next if Gem::Dependency.new("graphql", "< 1.12.0").match?("graphql", GraphQL::VERSION)
+
+  let(:query) { "query { user }" }
+  let(:query_str) { query }
+  let(:extensions) { {} }
+  let(:parsed_query) { GraphQL.parse(query) }
+  let(:compiled_query) { Marshal.dump(parsed_query) }
+  let(:store) do
+    double("TestStore").tap do |store|
+      allow(store).to receive(:save_query)
+      allow(store).to receive(:fetch_query).and_return(compiled_query)
+    end
+  end
+  let(:hash_generator_proc) { proc { |value| Digest::SHA256.hexdigest(value) } }
+  let(:hash) { hash_generator_proc.call(query) }
+  let(:error_handler) { GraphQL::PersistedQueries::ErrorHandlers::DefaultErrorHandler.new }
+
+  let(:schema) do
+    double("TestSchema").tap do |schema|
+      allow(schema).to receive(:persisted_query_store).and_return(store)
+      allow(schema).to receive(:hash_generator_proc).and_return(hash_generator_proc)
+      allow(schema).to receive(:persisted_query_error_handler).and_return(error_handler)
+    end
+  end
+
+  describe "#fetch" do
+    subject do
+      described_class.new(schema, extensions).fetch
+    end
+
+    context "when extensions hash is empty" do
+      it { is_expected.to be_nil }
+    end
+
+    context "when extensions hash is passed" do
+      let(:extensions) do
+        { "persistedQuery" => { "sha256Hash" => hash } }
+      end
+
+      it { is_expected.to eq(parsed_query) }
+
+      it "fetches query from store" do
+        subject
+        expect(store).to have_received(:fetch_query).with(hash, compiled_query: true)
+      end
+    end
+
+    context "when the store fails" do
+      let(:extensions) { { "persistedQuery" => { "sha256Hash" => hash } } }
+
+      let(:error_handler) do
+        handler = double("TestErrorHandler")
+        allow(handler).to receive(:call)
+        handler
+      end
+
+      let(:error) { StandardError.new }
+
+      let(:store) do
+        store = double("TestStore")
+        allow(store).to receive(:fetch_query).and_raise(error)
+        store
+      end
+
+      it "passes the error to the error handler" do
+        # rubocop: disable Lint/HandleExceptions
+        begin
+          subject
+        rescue GraphQL::PersistedQueries::Resolver::NotFound
+          # Ignore the expected error
+        end
+        # rubocop: enable Lint/HandleExceptions
+
+        expect(error_handler).to have_received(:call).with(error)
+      end
+    end
+  end
+
+  describe "#persist" do
+    subject do
+      described_class.new(schema, extensions).persist(query_str, parsed_query)
+    end
+
+    context "when extensions hash is empty" do
+      it "saves query to store" do
+        subject
+        expect(store).not_to have_received(:save_query)
+      end
+    end
+
+    context "when extensions hash is passed" do
+      let(:extensions) { { "persistedQuery" => { "sha256Hash" => hash } } }
+
+      it "saves query to store" do
+        subject
+        expect(store).to have_received(:save_query).with(hash, compiled_query, compiled_query: true)
+      end
+
+      context "when hash is incorrect" do
+        let(:hash) { "wrong" }
+
+        it "raises exception" do
+          expect { subject }.to raise_error(GraphQL::PersistedQueries::WrongHash)
+        end
+      end
+    end
+
+    context "when query_str is not provided" do
+      let(:query_str) { nil }
+
+      it "saves query to store" do
+        subject
+        expect(store).not_to have_received(:save_query)
+      end
+    end
+
+    context "when the store fails" do
+      let(:extensions) { { "persistedQuery" => { "sha256Hash" => hash } } }
+
+      let(:error_handler) do
+        handler = double("TestErrorHandler")
+        allow(handler).to receive(:call)
+        handler
+      end
+      let(:error) { StandardError.new }
+
+      let(:store) do
+        store = double("TestStore")
+        allow(store).to receive(:save_query).and_raise(error)
+        store
+      end
+
+      it "passes the error to the error handler" do
+        subject
+        expect(error_handler).to have_received(:call).with(error)
+      end
+    end
+  end
+end

--- a/spec/graphql/persisted_queries/multiplex_resolver_spec.rb
+++ b/spec/graphql/persisted_queries/multiplex_resolver_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe GraphQL::PersistedQueries::MultiplexResolver do
       described_class.new(schema, queries).resolve
     end
 
-    context "when cache is partially cold" do
+    context "when one query is not passed" do
       let(:query1) { nil }
       let(:sha256_1) { 1 }
 
@@ -45,7 +45,7 @@ RSpec.describe GraphQL::PersistedQueries::MultiplexResolver do
       end
     end
 
-    context "when cache is cold" do
+    context "when all queries are not passed" do
       let(:query1) { nil }
       let(:query2) { nil }
 
@@ -62,7 +62,7 @@ RSpec.describe GraphQL::PersistedQueries::MultiplexResolver do
       end
     end
 
-    context "when cache is warm" do
+    context "when all queries are passed" do
       it "returns data" do
         expect(subject).to eq(
           [

--- a/spec/graphql/persisted_queries/resolver_spec.rb
+++ b/spec/graphql/persisted_queries/resolver_spec.rb
@@ -52,9 +52,7 @@ RSpec.describe GraphQL::PersistedQueries::Resolver do
           let(:hash) { "wrong" }
 
           it "raises exception" do
-            expect { subject }.to raise_error(
-              GraphQL::PersistedQueries::Resolver::WrongHash
-            )
+            expect { subject }.to raise_error(GraphQL::PersistedQueries::WrongHash)
           end
         end
       end
@@ -91,7 +89,7 @@ RSpec.describe GraphQL::PersistedQueries::Resolver do
             # rubocop: disable Lint/HandleExceptions
             begin
               subject
-            rescue GraphQL::PersistedQueries::Resolver::NotFound
+            rescue GraphQL::PersistedQueries::NotFound
               # Ignore the expected error
             end
             # rubocop: enable Lint/HandleExceptions

--- a/spec/graphql/persisted_queries/schema_patch_spec.rb
+++ b/spec/graphql/persisted_queries/schema_patch_spec.rb
@@ -88,11 +88,11 @@ RSpec.describe GraphQL::PersistedQueries::SchemaPatch do
       let(:sha256) { 1 }
 
       UnavailableStore = Class.new(GraphQL::PersistedQueries::StoreAdapters::BaseStoreAdapter) do
-        def fetch_query(_)
+        def fetch_query(_, **_)
           raise "Store unavailable"
         end
 
-        def save_query(_, _)
+        def save_query(_, _, **_)
           raise "Store unavailable"
         end
       end

--- a/spec/graphql/persisted_queries/store_adapters/base_store_adapter_spec.rb
+++ b/spec/graphql/persisted_queries/store_adapters/base_store_adapter_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe GraphQL::PersistedQueries::StoreAdapters::BaseStoreAdapter do
     end
 
     def fetch(hash)
-      @storage[hash]
+      @storage.fetch(hash)
     end
 
     def save(hash, query)
@@ -22,10 +22,30 @@ RSpec.describe GraphQL::PersistedQueries::StoreAdapters::BaseStoreAdapter do
   end
 
   let(:storage) { {} }
+
   subject { TestableStoreAdapter.new(storage: storage) }
+
+  describe "#fetch" do
+    before do
+      allow(storage).to receive(:fetch)
+    end
+
+    it "uses hash as a key" do
+      subject.fetch_query("greenday")
+      expect(storage).to have_received(:fetch).with("greenday")
+    end
+
+    context "when compiled_query = true" do
+      it "adds 'compiled' to key" do
+        subject.fetch_query("greenday", compiled_query: true)
+        expect(storage).to have_received(:fetch).with("compiled:greenday")
+      end
+    end
+  end
 
   describe "tracing events" do
     let(:tracer) { TestTracer.new }
+
     before do
       subject.tracers = [tracer]
     end

--- a/spec/graphql/persisted_queries/store_adapters/base_store_adapter_spec.rb
+++ b/spec/graphql/persisted_queries/store_adapters/base_store_adapter_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe GraphQL::PersistedQueries::StoreAdapters::BaseStoreAdapter do
   end
 
   let(:storage) { {} }
+  let(:versioned_key_prefix) { "#{RUBY_ENGINE}-#{RUBY_VERSION}:#{GraphQL::VERSION}" }
 
   subject { TestableStoreAdapter.new(storage: storage) }
 
@@ -32,13 +33,13 @@ RSpec.describe GraphQL::PersistedQueries::StoreAdapters::BaseStoreAdapter do
 
     it "uses hash as a key" do
       subject.fetch_query("greenday")
-      expect(storage).to have_received(:fetch).with("greenday")
+      expect(storage).to have_received(:fetch).with("#{versioned_key_prefix}:greenday")
     end
 
     context "when compiled_query = true" do
       it "adds 'compiled' to key" do
         subject.fetch_query("greenday", compiled_query: true)
-        expect(storage).to have_received(:fetch).with("compiled:greenday")
+        expect(storage).to have_received(:fetch).with("compiled:#{versioned_key_prefix}:greenday")
       end
     end
   end
@@ -51,7 +52,7 @@ RSpec.describe GraphQL::PersistedQueries::StoreAdapters::BaseStoreAdapter do
     end
 
     it "emits a cache_miss event", focus: true do
-      storage["greenday"] = nil
+      storage["#{versioned_key_prefix}:greenday"] = nil
       subject.fetch_query("greenday")
 
       expect(tracer.events).to eq(
@@ -63,7 +64,7 @@ RSpec.describe GraphQL::PersistedQueries::StoreAdapters::BaseStoreAdapter do
     end
 
     it "emits a cache_hit event", focus: true do
-      storage["greenday"] = "welcome-to-paradise"
+      storage["#{versioned_key_prefix}:greenday"] = "welcome-to-paradise"
       subject.fetch_query("greenday")
 
       expect(tracer.events).to eq(


### PR DESCRIPTION
Works with 1.12.0 or later. How to try it: add `compiled_queries: true` to plugin initialization (`use GraphQL::PersistedQueries, compiled_queries: true`)

TODO:

- [x] specs! (+ make sure multiplex still works)
- [x] make sure it works with all versions since we patch private API
- [x] cleanup code and remove duplications
- [x] separate cache key (to bust existing cache)
- [x] benchmarks
- [x] readme
- [x] make benchmarks better, generate report and add to readme