### PR TITLE
Allow nil redis_client with ENV["REDIS_URL"]

### DIFF
--- a/docs/alternative_stores.md
+++ b/docs/alternative_stores.md
@@ -25,6 +25,9 @@ class GraphqlSchema < GraphQL::Schema
   use GraphQL::PersistedQueries,
       store: :redis,
       redis_client: ConnectionPool.new { Redis.new(url: "redis://127.0.0.2:2214/7") }
+  # or with ENV["REDIS_URL"]
+  use GraphQL::PersistedQueries,
+      store: :redis
 end
 ```
 

--- a/lib/graphql/persisted_queries/store_adapters/redis_store_adapter.rb
+++ b/lib/graphql/persisted_queries/store_adapters/redis_store_adapter.rb
@@ -10,7 +10,7 @@ module GraphQL
         DEFAULT_EXPIRATION = 24 * 60 * 60
         DEFAULT_NAMESPACE = "graphql-persisted-query"
 
-        def initialize(redis_client:, expiration: nil, namespace: nil)
+        def initialize(redis_client: {}, expiration: nil, namespace: nil)
           @redis_proc = build_redis_proc(redis_client)
           @expiration = expiration || DEFAULT_EXPIRATION
           @namespace = namespace || DEFAULT_NAMESPACE


### PR DESCRIPTION
Make redis_client optional so it will work with `ENV["REDIS_URL"]` without the need to pass an empty client. I added a test for empty client, happy to add more tests if required.


Fix: https://github.com/DmitryTsepelev/graphql-ruby-persisted_queries/issues/48