### PR TITLE
Support empty redis_client arg on redis with locale cache

### DIFF
--- a/lib/graphql/persisted_queries/store_adapters/redis_with_local_cache_store_adapter.rb
+++ b/lib/graphql/persisted_queries/store_adapters/redis_with_local_cache_store_adapter.rb
@@ -8,7 +8,7 @@ module GraphQL
         DEFAULT_REDIS_ADAPTER_CLASS = RedisStoreAdapter
         DEFAULT_MEMORY_ADAPTER_CLASS = MemoryStoreAdapter
 
-        def initialize(redis_client:, expiration: nil, namespace: nil, redis_adapter_class: nil,
+        def initialize(redis_client: {}, expiration: nil, namespace: nil, redis_adapter_class: nil,
                        memory_adapter_class: nil)
           redis_adapter_class ||= DEFAULT_REDIS_ADAPTER_CLASS
           memory_adapter_class ||= DEFAULT_MEMORY_ADAPTER_CLASS


### PR DESCRIPTION
In https://github.com/DmitryTsepelev/graphql-ruby-persisted_queries/pull/49, I added the option to skip `redis_client` when no specific options are required. I forgot to add the empty hash parameter to `redis_with_local_cache`. This makes it possible to skip the `redis_client` while using that adapter.