### PR TITLE
ensure the correct query object is being used for instrumentation

### DIFF
--- a/lib/graphql/persisted_queries/compiled_queries/instrumentation.rb
+++ b/lib/graphql/persisted_queries/compiled_queries/instrumentation.rb
@@ -8,6 +8,10 @@ module GraphQL
         class << self
           # Actions to perform before the query resolution
           def before_query(query)
+            if Gem::Dependency.new("graphql", ">= 2.5.6").match?("graphql", GraphQL::VERSION)
+              query = query.query if query.class.name == "GraphQL::Query::Partial"
+            end
+
             return unless query.context[:extensions]
 
             query.try_load_document!

--- a/lib/graphql/persisted_queries/compiled_queries/instrumentation.rb
+++ b/lib/graphql/persisted_queries/compiled_queries/instrumentation.rb
@@ -8,9 +8,7 @@ module GraphQL
         class << self
           # Actions to perform before the query resolution
           def before_query(query)
-            if Gem::Dependency.new("graphql", ">= 2.5.6").match?("graphql", GraphQL::VERSION)
-              query = query.query if query.class.name == "GraphQL::Query::Partial"
-            end
+            query = query.query if query.class.name == "GraphQL::Query::Partial"
 
             return unless query.context[:extensions]
 


### PR DESCRIPTION
Fixes an error that gets raised when tring to defer or stream requests on the latest version of graphql ruby.
`NoMethodError (undefined method try_load_document! for #<GraphQL::Query::Partial>)`.

Versions:
- graphql: 2.5.6
- graphql-pro: 1.29.7

The issue seems to happen because a new object was implemented and according to the internal docs it is supposed to behave like a wrapper for the parent object Query. Unfortunately it does not delegate the behavior so it requires any access to query data to be done explicitly.

I tested this locally and it seems to do the trick but I, tbh, am not sure if the solution is ideal.

I also don't know where the partial queries are used besides deferring and streaming, so I am not sure how to test it otherwise.