### PR TITLE
Add option to skip query marshalling for in-memory storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ It is possible to skip some parts of the query lifecycle for cases when query is
 
 An experimental tracing feature can be enabled by setting `tracing: true` when configuring the plugin. Read more about this feature in the [Tracing guide](docs/tracing.md).
 
+You can skip marshalling for queries stored in memory by passing the `marshal_inmemory_queries: false` option. This only affects the `memory` and `redis_with_local_cache` stores.
+
 > 📖 Read more about the gem internals: [Persisted queries in GraphQL:
 Slim down Apollo requests to your Ruby application](https://evilmartians.com/chronicles/persisted-queries-in-graphql-slim-down-apollo-requests-to-your-ruby-application)
 

--- a/benchmark/compiled_queries.rb
+++ b/benchmark/compiled_queries.rb
@@ -17,6 +17,12 @@ class GraphqlSchema < GraphQL::Schema
   query QueryType
 end
 
+class GraphqlSchemaWithoutMarshalling < GraphQL::Schema
+  use GraphQL::PersistedQueries, compiled_queries: true, marshal_inmemory_queries: false
+
+  query QueryType
+end
+
 GraphqlSchema.to_definition
 
 puts
@@ -32,9 +38,14 @@ Benchmark.bm(28) do |x|
       context = { extensions: { "persistedQuery" => { "sha256Hash" => sha256 } } }
       # warmup
       GraphqlSchema.execute(query, context: context)
+      GraphqlSchemaWithoutMarshalling.execute(query, context: context)
 
-      x.report("#{field_count} fields#{" (nested)" if with_nested}") do
+      x.report("#{field_count} fields#{' (nested)' if with_nested} (marshalled)") do
         GraphqlSchema.execute(query, context: context)
+      end
+
+      x.report("#{field_count} fields#{' (nested)' if with_nested}") do
+        GraphqlSchemaWithoutMarshalling.execute(query, context: context)
       end
     end
   end

--- a/graphql-persisted_queries.gemspec
+++ b/graphql-persisted_queries.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "redis"
   spec.add_development_dependency "dalli"
   spec.add_development_dependency "connection_pool"
+  spec.add_development_dependency "benchmark"
 end

--- a/lib/graphql/persisted_queries/compiled_queries/resolver.rb
+++ b/lib/graphql/persisted_queries/compiled_queries/resolver.rb
@@ -38,8 +38,7 @@ module GraphQL
           return if hash.nil?
 
           with_error_handling do
-            compiled_query = @schema.persisted_query_store.fetch_query(hash, compiled_query: true)
-            Marshal.load(compiled_query) if compiled_query # rubocop:disable Security/MarshalLoad
+            @schema.persisted_query_store.fetch_query(hash, compiled_query: true)
           end
         end
 
@@ -50,7 +49,7 @@ module GraphQL
 
           with_error_handling do
             @schema.persisted_query_store.save_query(
-              hash, Marshal.dump(compiled_query), compiled_query: true
+              hash, compiled_query, compiled_query: true
             )
           end
         end

--- a/lib/graphql/persisted_queries/store_adapters/base_store_adapter.rb
+++ b/lib/graphql/persisted_queries/store_adapters/base_store_adapter.rb
@@ -24,7 +24,9 @@ module GraphQL
 
         def save_query(hash, query, compiled_query: false)
           key = build_key(hash, compiled_query)
-          trace("save_query", adapter: @name) { save(key, query) }
+          trace("save_query", adapter: @name) do
+            query.tap { save(key, query) }
+          end
         end
 
         def fetch(_hash)
@@ -42,6 +44,14 @@ module GraphQL
           elsif block_given?
             yield
           end
+        end
+
+        def serialize(query)
+          Marshal.dump(query)
+        end
+
+        def deserialize(serialized_query)
+          Marshal.load(serialized_query) if serialized_query # rubocop:disable Security/MarshalLoad
         end
 
         private

--- a/lib/graphql/persisted_queries/store_adapters/memcached_store_adapter.rb
+++ b/lib/graphql/persisted_queries/store_adapters/memcached_store_adapter.rb
@@ -18,11 +18,11 @@ module GraphQL
         end
 
         def fetch(hash)
-          @dalli_proc.call { |dalli| dalli.get(key_for(hash)) }
+          @dalli_proc.call { |dalli| deserialize(dalli.get(key_for(hash))) }
         end
 
         def save(hash, query)
-          @dalli_proc.call { |dalli| dalli.set(key_for(hash), query, @expiration) }
+          @dalli_proc.call { |dalli| dalli.set(key_for(hash), serialize(query), @expiration) }
         end
 
         private

--- a/lib/graphql/persisted_queries/store_adapters/memory_store_adapter.rb
+++ b/lib/graphql/persisted_queries/store_adapters/memory_store_adapter.rb
@@ -5,17 +5,36 @@ module GraphQL
     module StoreAdapters
       # Memory adapter for storing persisted queries
       class MemoryStoreAdapter < BaseStoreAdapter
-        def initialize(**_options)
+        def initialize(**options)
           @storage = {}
           @name = :memory
+          @marshal_inmemory_queries = options.fetch(:marshal_inmemory_queries, true)
         end
 
         def fetch(hash)
-          @storage[hash]
+          deserialize(@storage[hash])
         end
 
         def save(hash, query)
-          @storage[hash] = query
+          @storage[hash] = serialize(query)
+        end
+
+        def serialize(query)
+          if @marshal_inmemory_queries
+            super(query)
+          else
+            query
+          end
+        end
+
+        def deserialize(serialized_query)
+          return unless serialized_query
+
+          if @marshal_inmemory_queries
+            super(serialized_query)
+          else
+            serialized_query
+          end
         end
       end
     end

--- a/lib/graphql/persisted_queries/store_adapters/redis_store_adapter.rb
+++ b/lib/graphql/persisted_queries/store_adapters/redis_store_adapter.rb
@@ -18,11 +18,13 @@ module GraphQL
         end
 
         def fetch(hash)
-          @redis_proc.call { |redis| redis.get(key_for(hash)) }
+          @redis_proc.call do |redis|
+            deserialize(redis.get(key_for(hash)))
+          end
         end
 
         def save(hash, query)
-          @redis_proc.call { |redis| redis.set(key_for(hash), query, ex: @expiration) }
+          @redis_proc.call { |redis| redis.set(key_for(hash), serialize(query), ex: @expiration) }
         end
 
         private

--- a/lib/graphql/persisted_queries/store_adapters/redis_with_local_cache_store_adapter.rb
+++ b/lib/graphql/persisted_queries/store_adapters/redis_with_local_cache_store_adapter.rb
@@ -8,8 +8,9 @@ module GraphQL
         DEFAULT_REDIS_ADAPTER_CLASS = RedisStoreAdapter
         DEFAULT_MEMORY_ADAPTER_CLASS = MemoryStoreAdapter
 
+        # rubocop:disable Metrics/ParameterLists, Metrics/MethodLength
         def initialize(redis_client: {}, expiration: nil, namespace: nil, redis_adapter_class: nil,
-                       memory_adapter_class: nil)
+                       memory_adapter_class: nil, marshal_inmemory_queries: true)
           redis_adapter_class ||= DEFAULT_REDIS_ADAPTER_CLASS
           memory_adapter_class ||= DEFAULT_MEMORY_ADAPTER_CLASS
 
@@ -18,9 +19,13 @@ module GraphQL
             expiration: expiration,
             namespace: namespace
           )
-          @memory_adapter = memory_adapter_class.new
+          @marshal_inmemory_queries = marshal_inmemory_queries
+          @memory_adapter = memory_adapter_class.new(
+            marshal_inmemory_queries: marshal_inmemory_queries
+          )
           @name = :redis_with_local_cache
         end
+        # rubocop:enable Metrics/ParameterLists, Metrics/MethodLength
 
         def fetch(hash)
           result = @memory_adapter.fetch(hash)

--- a/spec/graphql/persisted_queries/compiled_queries/resolver_spec.rb
+++ b/spec/graphql/persisted_queries/compiled_queries/resolver_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe GraphQL::PersistedQueries::CompiledQueries::Resolver,
   let(:query_str) { query }
   let(:extensions) { {} }
   let(:parsed_query) { GraphQL.parse(query) }
-  let(:compiled_query) { Marshal.dump(parsed_query) }
+  let(:compiled_query) { parsed_query }
   let(:store) do
     double("TestStore").tap do |store|
       allow(store).to receive(:save_query)

--- a/spec/graphql/persisted_queries/store_adapters/base_store_adapter_spec.rb
+++ b/spec/graphql/persisted_queries/store_adapters/base_store_adapter_spec.rb
@@ -19,6 +19,14 @@ RSpec.describe GraphQL::PersistedQueries::StoreAdapters::BaseStoreAdapter do
     def save(hash, query)
       @storage[hash] = query
     end
+
+    def serialize(query)
+      query
+    end
+
+    def deserialize(serialized_query)
+      serialized_query
+    end
   end
 
   let(:storage) { {} }

--- a/spec/graphql/persisted_queries/store_adapters/memcached_store_adapter_spec.rb
+++ b/spec/graphql/persisted_queries/store_adapters/memcached_store_adapter_spec.rb
@@ -85,4 +85,20 @@ RSpec.describe GraphQL::PersistedQueries::StoreAdapters::MemcachedStoreAdapter d
       )
     end
   end
+
+  describe "interaction with underlying client" do
+    let(:key) { "key" }
+    let(:value) { "value" }
+
+    let(:dalli_client) { proc { |&block| block.call(dalli_client_stub) } }
+    let(:dalli_client_stub) { instance_double(Dalli::Client, set: true, get: Marshal.dump(value)) }
+
+    specify do
+      subject.save(key, value)
+
+      expect(dalli_client_stub).to have_received(:set).once
+      expect(subject.fetch(key)).to eq(value)
+      expect(dalli_client_stub).to have_received(:get).with(end_with(key)).once
+    end
+  end
 end

--- a/spec/graphql/persisted_queries/store_adapters/memory_store_adapter_spec.rb
+++ b/spec/graphql/persisted_queries/store_adapters/memory_store_adapter_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe GraphQL::PersistedQueries::StoreAdapters::MemoryStoreAdapter do
+  subject { described_class.new(**options) }
+
+  let(:storage) { subject.instance_variable_get(:@storage) }
+
+  let(:key) { "key" }
+  let(:value) { "value" }
+
+  before { subject.save(key, value) }
+
+  context "when `marshal_inmemory_queries` is to to a truthy value" do
+    let(:options) { { marshal_inmemory_queries: true } }
+
+    it "loads serialized value by provided key" do
+      expect(storage.fetch(key)).to eq(Marshal.dump(value))
+      expect(subject.fetch(key)).to eq(value)
+    end
+  end
+
+  context "when `marshal_inmemory_queries` is to to a falsey value" do
+    let(:options) { { marshal_inmemory_queries: false } }
+
+    it "loads serialized value by provided key" do
+      expect(storage.fetch(key)).to eq(value)
+      expect(subject.fetch(key)).to eq(value)
+    end
+  end
+end

--- a/spec/graphql/persisted_queries/store_adapters/redis_store_adapter_spec.rb
+++ b/spec/graphql/persisted_queries/store_adapters/redis_store_adapter_spec.rb
@@ -94,4 +94,20 @@ RSpec.describe GraphQL::PersistedQueries::StoreAdapters::RedisStoreAdapter do
       )
     end
   end
+
+  describe "interaction with underlying client" do
+    let(:key) { "key" }
+    let(:value) { "value" }
+
+    let(:redis_client) { proc { |&block| block.call(redis_client_stub) } }
+    let(:redis_client_stub) { instance_double(Redis, set: true, get: Marshal.dump(value)) }
+
+    specify do
+      subject.save(key, value)
+
+      expect(redis_client_stub).to have_received(:set).once
+      expect(subject.fetch(key)).to eq(value)
+      expect(redis_client_stub).to have_received(:get).with(end_with(key)).once
+    end
+  end
 end

--- a/spec/graphql/persisted_queries/store_adapters/redis_with_local_cache_store_adapter_spec.rb
+++ b/spec/graphql/persisted_queries/store_adapters/redis_with_local_cache_store_adapter_spec.rb
@@ -21,13 +21,15 @@ RSpec.describe GraphQL::PersistedQueries::StoreAdapters::RedisWithLocalCacheStor
     allow(klass).to receive(:new).and_return(mock_memory_adapter)
     klass
   end
+  let(:marshal_inmemory_queries) { true }
   let(:options) do
     {
       redis_client: redis_client,
       expiration: nil,
       namespace: nil,
       redis_adapter_class: redis_adapter_class,
-      memory_adapter_class: memory_adapter_class
+      memory_adapter_class: memory_adapter_class,
+      marshal_inmemory_queries: marshal_inmemory_queries
     }
   end
 
@@ -134,6 +136,18 @@ RSpec.describe GraphQL::PersistedQueries::StoreAdapters::RedisWithLocalCacheStor
   end
 
   context "when saving queries" do
+    it "dispatches to both adapters" do
+      expect(mock_memory_adapter).to \
+        receive(:save).with("#{versioned_key_prefix}:abc123", "result!")
+
+      expect(mock_redis_adapter).to \
+        receive(:save).with("#{versioned_key_prefix}:abc123", "result!")
+
+      subject.save_query("abc123", "result!")
+    end
+  end
+
+  describe "interaction with underlying adapters" do
     it "dispatches to both adapters" do
       expect(mock_memory_adapter).to \
         receive(:save).with("#{versioned_key_prefix}:abc123", "result!")


### PR DESCRIPTION
When using `memory` or `redis_with_local_cache` as the store, we can make a small performance improvement by skipping query marshalling.

This helps to reduce latency spikes during application startup when caches are cold.

- Queries are immutable by design, so it should be safe to store them in memory as-is.
- Marshalling responsibility is now delegated to storage adapters, allowing custom adapters to implement their own marshalling logic.
- Marshalling can be disabled by setting `marshal_query` to `false` (default is `true`).
- Microbenchmarks show a ~10-20% speedup when marshalling is disabled:

```shell
10 fields (marshalled)            0.000227   0.000040   0.000267 (  0.000340)
10 fields                         0.000205   0.000036   0.000241 (  0.000280)
50 fields (marshalled)            0.000564   0.000000   0.000564 (  0.000627)
50 fields                         0.000499   0.000000   0.000499 (  0.000540)
100 fields (marshalled)           0.000870   0.000000   0.000870 (  0.000870)
100 fields                        0.000796   0.000000   0.000796 (  0.000796)
200 fields (marshalled)           0.001601   0.000000   0.001601 (  0.001674)
200 fields                        0.001246   0.000000   0.001246 (  0.001302)
300 fields (marshalled)           0.002239   0.000000   0.002239 (  0.002296)
300 fields                        0.002957   0.000000   0.002957 (  0.003024)
10 fields (nested) (marshalled)   0.000770   0.000124   0.000894 (  0.000919)
10 fields (nested)                0.000544   0.000088   0.000632 (  0.000675)
50 fields (nested) (marshalled)   0.012095   0.000000   0.012095 (  0.012086)
50 fields (nested)                0.009354   0.000000   0.009354 (  0.009409)
100 fields (nested) (marshalled)  0.055085   0.000991   0.056076 (  0.056037)
100 fields (nested)               0.037897   0.000000   0.037897 (  0.037817)
200 fields (nested) (marshalled)  0.198699   0.007980   0.206679 (  0.206352)
200 fields (nested)               0.140777   0.002982   0.143759 (  0.143439)
300 fields (nested) (marshalled)  0.490598   0.014017   0.504615 (  0.504283)
300 fields (nested)               0.318342   0.001000   0.319342 (  0.318976)
```

This is a breaking change, as it modifies the responsibilities of storage adapters. If the idea is accepted, I plan to add a proper spec for `MemoryStoreAdapter` and update the README.